### PR TITLE
Fix Evolution Chain: missing branches, duplicate forms, and mega-transform gaps

### DIFF
--- a/common/src/main/kotlin/com/cobbledex/CategorySizer.kt
+++ b/common/src/main/kotlin/com/cobbledex/CategorySizer.kt
@@ -32,16 +32,20 @@ object CategorySizer {
         if (recipes.isEmpty()) return PanelSize(200, 100)
         var maxW = PanelLayout.MIN_WIDTH
         var maxH = 80
-        var settled = true
-        for ((i, handle) in recipes.withIndex()) {
+        // This result is cached per category+dataVersion+language (getBounds
+        // above), so it only runs once per data load/reload - not worth an
+        // early-exit shortcut that can under-measure the panel when an
+        // outlier (e.g. a species with a very long evolution requirement
+        // list, or many "notable differences" bullet points) happens to sit
+        // outside whatever sample window a shortcut would have checked.
+        // Scanning every recipe here is what fixed text overflowing the
+        // Evolution and Alternate Forms panels.
+        for (handle in recipes) {
             try {
                 val w = handle.width
                 val h = handle.height
-                if (w > maxW) { maxW = w; settled = false }
-                if (h > maxH) { maxH = h; settled = false }
-                // If size hasn't grown in the last 50 recipes, the rest won't push it higher
-                if (settled && i >= 50) break
-                if (!settled && i % 50 == 49) settled = true
+                if (w > maxW) maxW = w
+                if (h > maxH) maxH = h
             } catch (_: Exception) {}
         }
         return PanelSize(

--- a/common/src/main/kotlin/com/cobbledex/CobbleDexMod.kt
+++ b/common/src/main/kotlin/com/cobbledex/CobbleDexMod.kt
@@ -39,7 +39,14 @@ object CobbleDexMod {
     fun tickReloadCheck() {
         RecipeViewerReloader.tick()
 
-        if (SpawnDataIndex.isFullyLoaded()) return
+        if (SpawnDataIndex.isFullyLoaded()) {
+            // Fires exactly once per session, right as data finishes
+            // loading - builds the icon/render atlas automatically if no
+            // valid cache exists yet, so players never have to know
+            // /cobbledex sprites build exists (see PokemonSpriteAtlas.ensureAtlas).
+            PokemonSpriteAtlas.ensureAtlas()
+            return
+        }
 
         reloadTickCounter++
         if (reloadTickCounter <= 2 || reloadTickCounter % 100 == 0) {
@@ -49,6 +56,7 @@ object CobbleDexMod {
 
     fun resetReloadTimer() {
         reloadTickCounter = 0
+        PokemonSpriteAtlas.resetEnsureAttempt()
         SpawnDataIndex.ensureLoadedAsync()
     }
 }

--- a/common/src/main/kotlin/com/cobbledex/DerivedDataBuilder.kt
+++ b/common/src/main/kotlin/com/cobbledex/DerivedDataBuilder.kt
@@ -13,10 +13,18 @@ object DerivedDataBuilder {
         snapshot: CobbleDexDataSnapshot,
         runtimeSpeciesNames: () -> Iterable<String> = ::loadRuntimeSpeciesNames,
     ): Result {
+        // Resolve aspect-qualified results (e.g. Riolu -> "lucario y", the
+        // Midnight form) to the specific form's own key, not just the bare
+        // species name - otherwise the reverse map only ever pointed at base
+        // Lucario, so Lucario (Midnight)'s own page never showed it came
+        // from Riolu. Snapshot.speciesInfo already has form entries (with
+        // their aspects) synced/loaded before this runs, so lookups work
+        // even though `enriched` below hasn't been built yet.
+        val reverseLookupQueries = CobbleDexDataQueries(snapshot)
         val reverseMap = mutableMapOf<String, MutableList<EvolutionInfo>>()
         for ((_, evolutions) in snapshot.evolutionsBySpecies) {
             for (evo in evolutions) {
-                val normalizedTo = SpeciesNameNormalizer.normalize(evo.toSpecies)
+                val normalizedTo = RecipeBuilder.resolveEvolutionTargetKey(evo.toSpecies, evo.toAspects, snapshot, reverseLookupQueries)
                 reverseMap.getOrPut(normalizedTo) { mutableListOf() }.add(evo)
             }
         }

--- a/common/src/main/kotlin/com/cobbledex/DerivedDataBuilder.kt
+++ b/common/src/main/kotlin/com/cobbledex/DerivedDataBuilder.kt
@@ -20,9 +20,66 @@ object DerivedDataBuilder {
         // from Riolu. Snapshot.speciesInfo already has form entries (with
         // their aspects) synced/loaded before this runs, so lookups work
         // even though `enriched` below hasn't been built yet.
+        // "Fusion" packs (e.g. Starlight Fusion) register their fusion results
+        // as plain forms with no real Cobblemon Evolution behind them at all -
+        // the only place a fusion is documented is the pokedex flavor text,
+        // and its phrasing isn't consistent ("A fusion of X and Y,
+        // possessing...", "Necrozma appears to have fully absorbed
+        // Metagross.", "...after fusing X and Y!"). Rather than match one
+        // sentence shape, gate on a loose fusion-indicator keyword and scan
+        // the whole resolved description for every known base species name
+        // that appears in it, then synthesize a forward evolution edge from
+        // *every* component species into the fusion result - including the
+        // fusion's own base species, so it shows up directly in that
+        // species' own evolution chain too, not just its separate "Otras
+        // formas/Megas" panel. Mirrors the equivalent fix in the companion
+        // Pokedex website's pipeline (pokedex-site/pipeline/src/index.ts).
+        val baseSpeciesNames = try {
+            com.cobblemon.mod.common.api.pokemon.PokemonSpecies.implemented.map { it.name.lowercase() }
+        } catch (_: Exception) { emptyList() }
+        val fusionIndicator = Regex("""\b(fusion|fusing|fused|absorbed?|absorbs)\b""", RegexOption.IGNORE_CASE)
+        val mutableEvolutionsBySpecies = snapshot.evolutionsBySpecies.mapValues { it.value.toMutableList() }.toMutableMap()
+        var fusionEdgeCount = 0
+        for ((formKey, info) in snapshot.speciesInfo) {
+            val descKey = info.description ?: continue
+            val descText = try { tr(descKey) } catch (_: Exception) { continue }
+            if (descText == descKey || descText.isBlank()) continue
+            if (!fusionIndicator.containsMatchIn(descText)) continue
+            val toSpecies = info.baseSpeciesName?.let { SpeciesNameNormalizer.normalize(it) } ?: formKey
+            val toAspects = info.formAspects
+            val componentNames = baseSpeciesNames.filter { name ->
+                Regex("\\b${Regex.escape(name)}\\b", RegexOption.IGNORE_CASE).containsMatchIn(descText)
+            }
+            if (componentNames.size < 2) continue
+            for (component in componentNames) {
+                val others = componentNames.filter { it != component }.joinToString(" + ") { titleCase(it) }
+                val evo = EvolutionInfo(
+                    id = "fusion_${component}_$formKey",
+                    fromSpecies = component,
+                    fromAspects = emptySet(),
+                    toSpecies = toSpecies,
+                    toAspects = toAspects,
+                    variant = "fusion",
+                    requirements = listOf(EvolutionRequirement("fusion_with", mapOf("partner" to others))),
+                    requiredContext = null,
+                    consumeHeldItem = false,
+                )
+                mutableEvolutionsBySpecies.getOrPut(component) { mutableListOf() }.add(evo)
+                fusionEdgeCount++
+            }
+        }
+        if (fusionEdgeCount > 0) DebugLog.info("Synthesized $fusionEdgeCount fusion evolution edges from pokedex description text.")
+
+        // Resolve aspect-qualified results (e.g. Riolu -> "lucario y", the
+        // Midnight form) to the specific form's own key, not just the bare
+        // species name - otherwise the reverse map only ever pointed at base
+        // Lucario, so Lucario (Midnight)'s own page never showed it came
+        // from Riolu. Snapshot.speciesInfo already has form entries (with
+        // their aspects) synced/loaded before this runs, so lookups work
+        // even though `enriched` below hasn't been built yet.
         val reverseLookupQueries = CobbleDexDataQueries(snapshot)
         val reverseMap = mutableMapOf<String, MutableList<EvolutionInfo>>()
-        for ((_, evolutions) in snapshot.evolutionsBySpecies) {
+        for ((_, evolutions) in mutableEvolutionsBySpecies) {
             for (evo in evolutions) {
                 val normalizedTo = RecipeBuilder.resolveEvolutionTargetKey(evo.toSpecies, evo.toAspects, snapshot, reverseLookupQueries)
                 reverseMap.getOrPut(normalizedTo) { mutableListOf() }.add(evo)
@@ -31,9 +88,9 @@ object DerivedDataBuilder {
 
         val enriched = snapshot.speciesInfo.toMutableMap()
         var backfilled = 0
-        for (key in snapshot.evolutionsBySpecies.keys) {
+        for (key in mutableEvolutionsBySpecies.keys) {
             if (key in enriched) continue
-            val evos = snapshot.evolutionsBySpecies[key] ?: continue
+            val evos = mutableEvolutionsBySpecies[key] ?: continue
             val baseName = SpeciesNameNormalizer.normalize(evos.firstOrNull()?.fromSpecies ?: continue)
             val baseInfo = enriched[baseName] ?: continue
             enriched[key] = baseInfo.copy(
@@ -46,8 +103,8 @@ object DerivedDataBuilder {
 
         val allNames = mutableSetOf<String>()
         allNames.addAll(snapshot.spawnsBySpecies.keys)
-        allNames.addAll(snapshot.evolutionsBySpecies.keys)
-        for ((_, evos) in snapshot.evolutionsBySpecies) {
+        allNames.addAll(mutableEvolutionsBySpecies.keys)
+        for ((_, evos) in mutableEvolutionsBySpecies) {
             for (evo in evos) allNames.add(SpeciesNameNormalizer.normalize(evo.toSpecies))
         }
         allNames.addAll(enriched.keys)
@@ -82,6 +139,7 @@ object DerivedDataBuilder {
 
         return Result(
             snapshot = snapshot.copy(
+                evolutionsBySpecies = mutableEvolutionsBySpecies,
                 evolutionsToSpecies = reverseMap,
                 speciesInfo = enriched,
                 dropsByItem = dropIndex,

--- a/common/src/main/kotlin/com/cobbledex/DexCategory.kt
+++ b/common/src/main/kotlin/com/cobbledex/DexCategory.kt
@@ -194,8 +194,26 @@ object EvolutionDex : DexCategory {
     override fun buildAllRecipes(): List<RecipeHandle> =
         RecipeBuilder.buildAllEvolutionRecipes().map(::toHandle)
 
-    override fun buildRecipesFor(species: String): List<RecipeHandle> =
-        RecipeBuilder.buildEvolutionRecipesInto(species).map(::toHandle)
+    // The Pokemon Overview navigator only ever calls buildRecipesFor per
+    // category (never buildUsagesFor) - so a species with no INCOMING
+    // evolution (e.g. a base form like Eevee) showed no Evolution tab at all,
+    // even though it has plenty of OUTGOING branches. Combine both directions
+    // here so every member of a family (base or evolved) shows its full
+    // evolution info - what it comes from AND what it can become.
+    override fun buildRecipesFor(species: String): List<RecipeHandle> {
+        val incoming = RecipeBuilder.buildEvolutionRecipesInto(species).filter { it.targetSpeciesName != null }
+        val outgoing = RecipeBuilder.buildEvolutionPagesFor(species).filter { it.targetSpeciesName != null }
+        val combined = incoming + outgoing
+        if (combined.isEmpty()) {
+            // Neither direction has real data - fall back to the plain
+            // "no evolutions" placeholder instead of showing nothing.
+            return RecipeBuilder.buildEvolutionPagesFor(species).map(::toHandle)
+        }
+        val total = combined.size
+        return combined
+            .mapIndexed { index, data -> data.copy(pageIndex = index + 1, pageTotal = total, totalOutcomes = total) }
+            .map(::toHandle)
+    }
 
     override fun buildUsagesFor(species: String): List<RecipeHandle> =
         RecipeBuilder.buildEvolutionPagesFor(species).map(::toHandle)

--- a/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
+++ b/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
@@ -96,6 +96,23 @@ object DiagnosticService {
                 sender.send("    §fid=${evo.id} result=${evo.result.species}/${evo.result.aspects}")
             }
         }
+
+        // The processed data RecipeBuilder/EvolutionDex actually consume -
+        // includes CobbleDex's own synthesized entries (fusion edges, etc),
+        // not just what Cobblemon itself reports above.
+        val normalized = SpeciesNameNormalizer.normalize(speciesName)
+        sender.send("§6Processed evolutionsBySpecies[$normalized] (outgoing, what RecipeBuilder sees):")
+        val outgoing = SpawnDataIndex.getEvolutionsFrom(normalized)
+        if (outgoing.isEmpty()) sender.send("  §7(none)")
+        for (evo in outgoing) {
+            sender.send("  §ffrom=${evo.fromSpecies}${evo.fromAspects} to=${evo.toSpecies}${evo.toAspects} variant=${evo.variant} id=${evo.id}")
+        }
+        sender.send("§6Processed evolutionsToSpecies[$normalized] (incoming):")
+        val incoming = SpawnDataIndex.getEvolutionsTo(normalized)
+        if (incoming.isEmpty()) sender.send("  §7(none)")
+        for (evo in incoming) {
+            sender.send("  §ffrom=${evo.fromSpecies}${evo.fromAspects} to=${evo.toSpecies}${evo.toAspects} variant=${evo.variant} id=${evo.id}")
+        }
         return 1
     }
 

--- a/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
+++ b/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
@@ -41,6 +41,58 @@ object DiagnosticService {
         return 1
     }
     
+    // Bypasses all of CobbleDex's own form-loading/dedup logic and prints
+    // exactly what Cobblemon's live Species API reports for one species -
+    // used to debug cases where a bogus alternate-form entry (e.g. a
+    // cosmetic resourcepack skin) shows up and it's unclear whether
+    // Cobblemon itself is reporting it as a form or CobbleDex is
+    // synthesizing it.
+    fun showRawForms(speciesName: String, sender: MessageSender): Int {
+        val species = try {
+            PokemonSpecies.getByName(speciesName.lowercase())
+        } catch (e: Exception) {
+            sender.send("§cFailed to look up species: ${e.message}")
+            return 0
+        }
+        if (species == null) {
+            sender.send("§cSpecies not found in Cobblemon runtime: $speciesName")
+            return 0
+        }
+        sender.send("§6Raw Cobblemon forms for ${species.name}:")
+        val standardForm = try { species.standardForm } catch (_: Exception) { null }
+        sender.send("§7standardForm: name=${standardForm?.name} aspects=${standardForm?.aspects}")
+        val forms = try { species.forms } catch (e: Exception) {
+            sender.send("§cFailed to access species.forms: ${e.message}")
+            return 0
+        }
+        sender.send("§7Total forms: ${forms.size}")
+        for (form in forms) {
+            val isStandard = form === standardForm
+            sender.send("  §fname=\"${form.name}\" aspects=${form.aspects} isStandard=$isStandard")
+        }
+
+        sender.send("§6species.evolutions (base-level):")
+        val baseEvos = try { species.evolutions } catch (e: Exception) {
+            sender.send("§cFailed to access species.evolutions: ${e.message}")
+            emptyList()
+        }
+        if (baseEvos.isEmpty()) sender.send("  §7(none)")
+        for (evo in baseEvos) {
+            sender.send("  §fid=${evo.id} result=${evo.result.species}/${evo.result.aspects}")
+        }
+
+        sender.send("§6Per-form evolutions:")
+        for (form in forms) {
+            val formEvos = try { form.evolutions } catch (_: Exception) { continue }
+            if (formEvos.isEmpty()) continue
+            sender.send("  §7form=\"${form.name}\" aspects=${form.aspects}:")
+            for (evo in formEvos) {
+                sender.send("    §fid=${evo.id} result=${evo.result.species}/${evo.result.aspects}")
+            }
+        }
+        return 1
+    }
+
     fun showMissing(sender: MessageSender): Int {
         val index = SpawnDataIndex
         

--- a/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
+++ b/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
@@ -116,6 +116,114 @@ object DiagnosticService {
         return 1
     }
 
+    // Calls the exact same RecipeBuilder functions the REI/EMI Evolution tab
+    // calls (EvolutionDex.buildRecipesFor), using the same form-key string a
+    // Pokemon entry would carry (e.g. "fomantis_lunar"). Used to tell apart
+    // "the data pipeline never produced this edge" (showRawForms would show
+    // that) from "the pipeline has it right, but REI is asking for the wrong
+    // key or something in RecipeBuilder's per-form lookup misses it" - this
+    // command bypasses REI entirely and prints RecipeBuilder's raw output.
+    fun showEvoPages(formKey: String, sender: MessageSender): Int {
+        val normalized = SpeciesNameNormalizer.normalize(formKey)
+        val queries = CobbleDexDataQueries(SpawnDataIndex.currentSnapshot())
+
+        sender.send("§6buildEvolutionPagesFor($normalized) (outgoing, what the Evolution tab calls):")
+        val outgoing = RecipeBuilder.buildEvolutionPagesFor(normalized)
+        for (page in outgoing) {
+            sender.send("  §fpage=${page.pageIndex}/${page.pageTotal} target=${page.targetSpeciesName}${page.targetAspects} methods=${page.methods.map { it.requirementText }}")
+        }
+        if (outgoing.isEmpty()) sender.send("  §7(empty list)")
+
+        sender.send("§6buildEvolutionRecipesInto($normalized) (incoming, what the Evolution tab calls):")
+        val incoming = RecipeBuilder.buildEvolutionRecipesInto(normalized)
+        for (page in incoming) {
+            sender.send("  §fsource=${page.sourceSpeciesName}${page.sourceAspects} target=${page.targetSpeciesName}${page.targetAspects} methods=${page.methods.map { it.requirementText }}")
+        }
+        if (incoming.isEmpty()) sender.send("  §7(empty list)")
+
+        sender.send("§6getSpeciesInfo($normalized):")
+        val info = queries.getSpeciesInfo(normalized)
+        if (info == null) sender.send("  §7(null - not in speciesInfo)")
+        else sender.send("  §fname=${info.name} baseSpeciesName=${info.baseSpeciesName} formAspects=${info.formAspects} isForm=${info.isForm}")
+
+        // Direct raw map lookup, bypassing RecipeBuilder entirely - and every
+        // key in the whole snapshot that starts with the same prefix, in case
+        // the real stored key differs subtly from what we expect (missing
+        // underscore, different casing survives normalize, etc).
+        val snapshot = SpawnDataIndex.currentSnapshot()
+        sender.send("§6Raw snapshot.evolutionsBySpecies[$normalized]:")
+        val raw = snapshot.evolutionsBySpecies[normalized]
+        if (raw == null) sender.send("  §7(key not present in map)")
+        else if (raw.isEmpty()) sender.send("  §7(key present, empty list)")
+        else for (evo in raw) sender.send("  §ffrom=${evo.fromSpecies}${evo.fromAspects} to=${evo.toSpecies}${evo.toAspects} variant=${evo.variant} id=${evo.id}")
+
+        val prefix = normalized.substringBefore('_')
+        val matchingKeys = snapshot.evolutionsBySpecies.keys.filter { it.startsWith(prefix) }.sorted()
+        sender.send("§6All evolutionsBySpecies keys starting with '$prefix': $matchingKeys")
+
+        // showRawForms looks up the species via PokemonSpecies.getByName, but
+        // EvolutionDataLoader.loadFromRuntime() (which actually populates
+        // evolutionsBySpecies) iterates PokemonSpecies.implemented instead.
+        // If those two return different Species/FormData instances for the
+        // same species (e.g. a stale duplicate left behind by a runtime data
+        // reload), buildFormEntryKey could compute two different keys for
+        // what looks like "the same" form in showRawForms vs here - this
+        // replicates loadFromRuntime()'s exact lookup path to check for that.
+        sender.send("§6Via PokemonSpecies.implemented (what loadFromRuntime iterates):")
+        try {
+            val implementedSpecies = com.cobblemon.mod.common.api.pokemon.PokemonSpecies.implemented
+                .filter { it.name.equals(prefix, ignoreCase = true) }
+            sender.send("  §fmatching species instances: ${implementedSpecies.size}")
+            for (sp in implementedSpecies) {
+                val spEvos = try { sp.evolutions } catch (_: Exception) { emptyList() }
+                sender.send("  §fspecies instance ${System.identityHashCode(sp)}: species.evolutions=${spEvos.size}")
+                val forms = try { sp.forms } catch (_: Exception) { emptyList() }
+                sender.send("  §f  ${forms.size} forms")
+                for (form in forms) {
+                    val fEvos = try { form.evolutions } catch (_: Exception) { emptyList() }
+                    val computedKey = EvolutionDataLoader.buildFormEntryKey(prefix, form, sp)
+                    val lvlCount = try { form.moves.levelUpMoves.values.sumOf { it.size } } catch (_: Exception) { -1 }
+                    val eggCount = try { form.moves.eggMoves.size } catch (_: Exception) { -1 }
+                    val tutorCount = try { form.moves.tutorMoves.size } catch (_: Exception) { -1 }
+                    val tmCount = try { form.moves.tmMoves.size } catch (_: Exception) { -1 }
+                    sender.send("    §fname=\"${form.name}\" aspects=${form.aspects} evolutions=${fEvos.size} computedKey=$computedKey")
+                    sender.send("      §7moves: levelUp=$lvlCount egg=$eggCount tutor=$tutorCount tm=$tmCount primaryType=${try { form.primaryType } catch (_: Exception) { "?" }}")
+                }
+            }
+        } catch (e: Exception) {
+            sender.send("  §c${e.message}")
+        }
+
+        // Broader net: any TOP-LEVEL species (not form) whose own .name
+        // contains our prefix - e.g. if a mod registered "Fomantis Lunar" as
+        // its own separate species (not just a form/aspect of "Fomantis"),
+        // its species.evolutions would get keyed by its raw (space-containing)
+        // name, and SpeciesNameNormalizer strips spaces without inserting a
+        // separator - "fomantis lunar" -> "fomantislunar". That would explain
+        // an evolutionsBySpecies key with no underscore that showRawForms
+        // (which only looks at the real "Fomantis" species's own forms) would
+        // never see, since it's a completely separate species registration.
+        sender.send("§6All top-level species whose name contains '$prefix' (not exact match):")
+        try {
+            val containing = com.cobblemon.mod.common.api.pokemon.PokemonSpecies.implemented
+                .filter { it.name.contains(prefix, ignoreCase = true) && !it.name.equals(prefix, ignoreCase = true) }
+            if (containing.isEmpty()) sender.send("  §7(none found)")
+            for (sp in containing) {
+                val spEvos = try { sp.evolutions } catch (_: Exception) { emptyList() }
+                sender.send("  §fname=\"${sp.name}\" species.evolutions=${spEvos.size} normalizedKey=${SpeciesNameNormalizer.normalize(sp.name)}")
+                for (evo in spEvos) {
+                    val resultSpecies = try { evo.result.species } catch (_: Exception) { null }
+                    sender.send("    §fevo id=${evo.id} result.species=$resultSpecies result.aspects=${try { evo.result.aspects } catch (_: Exception) { null }}")
+                }
+            }
+        } catch (e: Exception) {
+            sender.send("  §c${e.message}")
+        }
+
+        sender.send("§6shouldSurfaceSpecies($normalized): ${queries.shouldSurfaceSpecies(normalized)}")
+        return 1
+    }
+
     fun showMissing(sender: MessageSender): Int {
         val index = SpawnDataIndex
         

--- a/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
+++ b/common/src/main/kotlin/com/cobbledex/DiagnosticService.kt
@@ -66,9 +66,15 @@ object DiagnosticService {
             return 0
         }
         sender.send("§7Total forms: ${forms.size}")
+        val queries = SpawnDataIndex.currentQueries()
         for (form in forms) {
             val isStandard = form === standardForm
-            sender.send("  §fname=\"${form.name}\" aspects=${form.aspects} isStandard=$isStandard")
+            val included = try { EvolutionDataLoader.shouldIncludeForm(species, form, standardForm) } catch (e: Exception) { "ERROR: ${e.message}" }
+            val formKey = try { EvolutionDataLoader.buildFormEntryKey(species.name.lowercase(), form, species) } catch (e: Exception) { "ERROR: ${e.message}" }
+            val inSpeciesInfo = SpawnDataIndex.speciesInfo.containsKey(formKey)
+            val surfaced = try { queries.shouldSurfaceSpecies(formKey) } catch (e: Exception) { "ERROR: ${e.message}" }
+            sender.send("  §fname=\"${form.name}\" aspects=${form.aspects} labels=${form.labels} isStandard=$isStandard")
+            sender.send("    §7shouldIncludeForm=$included formKey=$formKey inSpeciesInfo=$inSpeciesInfo surfaced=$surfaced")
         }
 
         sender.send("§6species.evolutions (base-level):")

--- a/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
+++ b/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
@@ -748,8 +748,17 @@ object EvolutionDataLoader {
             yieldMap.ifEmpty { null }
         } catch (_: Exception) { null }
 
+        // A form's moves being empty is Cobblemon's convention for "inherit the
+        // base form's moveset", not "this form learns nothing" - confirmed via
+        // vanilla Cobblemon's own gimmighoul.json, whose "Roaming" form has
+        // "moves": [] on purpose (Roaming and Chest Gimmighoul learn the same
+        // moves as base Gimmighoul). abilities/eggGroups a few lines below
+        // already fall back to baseForm when the form's own value is empty;
+        // the four move lists here didn't, so any form relying on this
+        // convention (rather than genuinely overriding its moveset) silently
+        // lost its entire learnset with no fallback.
         val levelUpMoves = try {
-            val moves = form.moves.levelUpMoves
+            val moves = form.moves.levelUpMoves.ifEmpty { baseForm?.moves?.levelUpMoves ?: emptyMap() }
             if (moves.isNotEmpty()) {
                 val grouped = mutableMapOf<Int, MutableList<MoveDetail>>()
                 for ((level, moveList) in moves) {
@@ -764,15 +773,18 @@ object EvolutionDataLoader {
         } catch (_: Exception) { null }
 
         val eggMoves = try {
-            form.moves.eggMoves.map { toMoveDetail(it) }.ifEmpty { null }
+            form.moves.eggMoves.ifEmpty { baseForm?.moves?.eggMoves ?: emptyList() }
+                .map { toMoveDetail(it) }.ifEmpty { null }
         } catch (_: Exception) { null }
 
         val tutorMoves = try {
-            form.moves.tutorMoves.map { toMoveDetail(it) }.ifEmpty { null }
+            form.moves.tutorMoves.ifEmpty { baseForm?.moves?.tutorMoves ?: emptyList() }
+                .map { toMoveDetail(it) }.ifEmpty { null }
         } catch (_: Exception) { null }
 
         val tmMoves = try {
-            form.moves.tmMoves.map { toMoveDetail(it) }.ifEmpty { null }
+            form.moves.tmMoves.ifEmpty { baseForm?.moves?.tmMoves ?: emptyList() }
+                .map { toMoveDetail(it) }.ifEmpty { null }
         } catch (_: Exception) { null }
 
         // Build the form name for i18n: preserve original casing with hyphens (e.g. "mega-x", "therian")

--- a/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
+++ b/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
@@ -622,6 +622,25 @@ object EvolutionDataLoader {
         "paldean_form" to "paldean"
     )
 
+    // Same regional suffixes, keyed by the form's own ASPECT instead of its
+    // labels - a form's labels can end up wrong at runtime for reasons
+    // outside any mod's own JSON (confirmed via /cobbledex forms: Farfetch'd
+    // Galar's own species_additions file and Cobblemon's base file both
+    // correctly declare labels=[gen8, galarian_form], but Cobblemon's
+    // runtime FormData reported labels=[gen1, kantonian_form] instead - a
+    // stale/conflicting value from elsewhere in the load pipeline). The
+    // aspect ("galarian") was still correct, so checking it as a fallback
+    // keeps the computed key ("farfetchdgalarian") matching what
+    // JarDataCache's raw-JSON-based key builder computes from the (correct)
+    // source labels, instead of silently falling back to the generic
+    // underscore scheme and breaking JAR-move-fallback lookups.
+    private val REGIONAL_ASPECT_TO_SUFFIX = mapOf(
+        "alolan" to "alolan",
+        "galarian" to "galarian",
+        "hisuian" to "hisuian",
+        "paldean" to "paldean"
+    )
+
     // Not private: DiagnosticService.showRawForms calls this directly to show
     // exactly why a given form was or wasn't surfaced as an alternate form.
     fun shouldIncludeForm(species: com.cobblemon.mod.common.pokemon.Species, form: com.cobblemon.mod.common.pokemon.FormData, baseForm: com.cobblemon.mod.common.pokemon.FormData?): Boolean {
@@ -668,9 +687,13 @@ object EvolutionDataLoader {
     fun buildFormEntryKey(baseName: String, form: com.cobblemon.mod.common.pokemon.FormData, species: com.cobblemon.mod.common.pokemon.Species): String {
         // Regional forms reuse SpeciesNameNormalizer's pattern for dedup with spawn data (O3)
         val regionalLabel = form.labels.firstOrNull { it in REGIONAL_LABEL_TO_SUFFIX }
-        if (regionalLabel != null) {
-            val suffix = REGIONAL_LABEL_TO_SUFFIX[regionalLabel]!!
-            return "${SpeciesNameNormalizer.normalize(baseName)}$suffix"
+        val regionalSuffix = if (regionalLabel != null) {
+            REGIONAL_LABEL_TO_SUFFIX[regionalLabel]!!
+        } else {
+            form.aspects.map { it.lowercase() }.firstNotNullOfOrNull { REGIONAL_ASPECT_TO_SUFFIX[it] }
+        }
+        if (regionalSuffix != null) {
+            return "${SpeciesNameNormalizer.normalize(baseName)}$regionalSuffix"
         }
         // Non-regional: underscore-separated normalized key (O12)
         val normalizedFormName = form.name.lowercase().replace(Regex("[^a-z0-9]"), "")
@@ -713,7 +736,18 @@ object EvolutionDataLoader {
         } catch (_: Exception) { Pair(null, null) }
 
         val primaryType = try { form.primaryType?.name?.lowercase() ?: species.primaryType?.name?.lowercase() ?: "normal" } catch (_: Exception) { "normal" }
-        val secondaryType = try { form.secondaryType?.name?.lowercase() ?: species.secondaryType?.name?.lowercase() } catch (_: Exception) { null }
+        // form.secondaryType being null is a real, meaningful value - "this
+        // form is mono-typed" - not "not specified, inherit the base
+        // species' type". Cobblemon fully resolves every form's own type at
+        // data-load time (unlike abilities/moves, which use an empty list as
+        // "no override" since a real Pokemon can't have zero abilities),
+        // so falling back to species.secondaryType here silently re-added a
+        // secondary type the form deliberately dropped - confirmed via
+        // Fai's Mythical Monstrosities' Sableye (Bloodmoon), whose form JSON
+        // sets primaryType=dark with no secondaryType at all (intentionally
+        // mono-type), but showed as Dark/Ghost (inheriting base Sableye's
+        // Ghost typing) until this fallback was removed.
+        val secondaryType = try { form.secondaryType?.name?.lowercase() } catch (_: Exception) { null }
 
         val eggGroups = try {
             val groups = form.eggGroups.ifEmpty { species.eggGroups }

--- a/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
+++ b/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
@@ -70,6 +70,15 @@ object EvolutionDataLoader {
                 val formEvos = try { form.evolutions } catch (_: Exception) { continue }
                 if (formEvos.isEmpty()) continue
                 val formAspects = form.aspects.toSet()
+                // Cobblemon registers every species' own baseline look as a form
+                // in its own right (typically named "Normal", with no aspect tag
+                // of its own) alongside genuinely distinct forms like Gmax/Alolan.
+                // Without this check that "Normal" form was being treated as a
+                // real alternate form - creating a bogus "<species>_normal" entry
+                // for essentially every species with any registered form, and
+                // double-counting the base species' own evolutions (added once
+                // from species.evolutions above, then again here).
+                if (formAspects.isEmpty()) continue
                 val formKey = buildFormEntryKey(baseName, form, species)
 
                 for (evo in formEvos) {
@@ -539,11 +548,25 @@ object EvolutionDataLoader {
         // Load alternate forms as separate entries
         if (com.cobbledex.config.CobbleDexConfig.get().showAlternateForms) {
             var formCount = 0
+            var skippedDuplicateAspectCount = 0
             for (species in implemented) {
                 val baseName = species.name.lowercase()
                 val baseForm = try { species.standardForm } catch (_: Exception) { null }
-                for (form in try { species.forms } catch (_: Exception) { emptyList() }) {
-                    if (!shouldIncludeForm(species, form, baseForm)) continue
+                // shouldIncludeForm already drops cosmetic "-costume" forms (see
+                // its comment). This grouping is just a safety net in case two
+                // eligible forms still end up sharing one aspect set for some
+                // other reason - keep the shortest/cleanest name in that case.
+                val eligibleForms = try { species.forms } catch (_: Exception) { emptyList() }
+                    .filter { form -> shouldIncludeForm(species, form, baseForm) }
+                val winningForms = eligibleForms
+                    .groupBy { form -> form.aspects.map { it.lowercase() }.toSet() }
+                    .flatMap { (aspectKey, candidates) ->
+                        if (aspectKey.isEmpty() || candidates.size <= 1) candidates
+                        else listOf(candidates.minBy { it.name.length })
+                    }
+                skippedDuplicateAspectCount += eligibleForms.size - winningForms.size
+
+                for (form in winningForms) {
                     try {
                         val formKey = buildFormEntryKey(baseName, form, species)
                         val info = buildFormSpeciesInfo(formKey, species, form, baseForm)
@@ -560,7 +583,7 @@ object EvolutionDataLoader {
                     }
                 }
             }
-            DebugLog.info("Loaded ${result.size} species from runtime API ($dropSpeciesCount with drops, $formCount alternate forms)")
+            DebugLog.info("Loaded ${result.size} species from runtime API ($dropSpeciesCount with drops, $formCount alternate forms, $skippedDuplicateAspectCount cosmetic-skin duplicates skipped)")
         } else {
             DebugLog.info("Loaded ${result.size} species from runtime API ($dropSpeciesCount with drops, alternate forms disabled)")
         }
@@ -584,7 +607,27 @@ object EvolutionDataLoader {
         if (baseForm != null && form == baseForm) return false
         if (form.name.isBlank()) return false
 
+        // Cobblemon's cosmetic-item system (wardrobe costumes granted via
+        // consumable items, e.g. data/cobblemon/cosmetic_items/*.json) tags
+        // every aspect it contributes with a "-costume" suffix (confirmed via
+        // /cobbledex forms: Lucario has real forms like "Mega" aspects=[mega]
+        // alongside cosmetic ones like "Mega-Chef-Costume" aspects=[chef-costume, mega]
+        // and standalone "Cafe-Costume" aspects=[cafe-costume]). These ARE genuine
+        // FormData entries registered by Cobblemon at runtime - not a bug in
+        // another mod - but they're purely cosmetic reskins, not gameplay forms,
+        // so they must never surface as alternate forms or evolution outcomes.
+        if (form.aspects.any { it.endsWith("-costume", ignoreCase = true) }) return false
+
         if (form.labels.any { it in SIGNIFICANT_LABELS }) return true
+
+        // A form with no distinguishing aspect can't meaningfully differ from
+        // the species' own look (same "empty aspects = same as base" convention
+        // used elsewhere for evolution data). Some species_additions patches
+        // register their own copy of the base/"Normal" form that isn't
+        // reference-equal to species.standardForm, so the check above alone
+        // doesn't catch it - this is what was surfacing as a bogus
+        // "<species> Normal" alternate form for most of the dex.
+        if (form.aspects.isEmpty()) return false
 
         val base = baseForm ?: return false
         val typeDiffers = form.primaryType != base.primaryType || form.secondaryType != base.secondaryType

--- a/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
+++ b/common/src/main/kotlin/com/cobbledex/EvolutionDataLoader.kt
@@ -596,6 +596,25 @@ object EvolutionDataLoader {
         "alolan_form", "galarian_form", "hisuian_form", "paldean_form"
     )
 
+    // Same idea as SIGNIFICANT_LABELS, but matched against the form's own
+    // ASPECT instead of its labels - some packs (or a species_additions patch
+    // from a different mod) ship a form whose labels don't carry the
+    // "gmax"/"mega"/etc marker at all (e.g. this modpack's live Eevee Gmax
+    // form reports labels=[gen1], not [gen8, gmax], even though its aspect is
+    // still plainly "gmax") - relying on labels alone silently dropped these.
+    // Aspects are the more reliable signal since Cobblemon itself keys pose/
+    // texture resolution off them, so a mod overriding flavor labels is much
+    // less likely to also break the aspect string.
+    private val SIGNIFICANT_ASPECT_MARKERS = setOf(
+        "mega", "primal", "ultra_burst", "gmax", "gigantamax",
+        "alolan", "galarian", "hisuian", "paldean", "alola", "galar", "hisui", "paldea"
+    )
+
+    private fun hasSignificantAspect(aspects: Set<String>): Boolean = aspects.any { aspect ->
+        val lower = aspect.lowercase()
+        SIGNIFICANT_ASPECT_MARKERS.any { marker -> lower == marker || lower.startsWith("${marker}_") || lower.startsWith("${marker}-") }
+    }
+
     private val REGIONAL_LABEL_TO_SUFFIX = mapOf(
         "alolan_form" to "alolan",
         "galarian_form" to "galarian",
@@ -603,7 +622,9 @@ object EvolutionDataLoader {
         "paldean_form" to "paldean"
     )
 
-    private fun shouldIncludeForm(species: com.cobblemon.mod.common.pokemon.Species, form: com.cobblemon.mod.common.pokemon.FormData, baseForm: com.cobblemon.mod.common.pokemon.FormData?): Boolean {
+    // Not private: DiagnosticService.showRawForms calls this directly to show
+    // exactly why a given form was or wasn't surfaced as an alternate form.
+    fun shouldIncludeForm(species: com.cobblemon.mod.common.pokemon.Species, form: com.cobblemon.mod.common.pokemon.FormData, baseForm: com.cobblemon.mod.common.pokemon.FormData?): Boolean {
         if (baseForm != null && form == baseForm) return false
         if (form.name.isBlank()) return false
 
@@ -619,6 +640,7 @@ object EvolutionDataLoader {
         if (form.aspects.any { it.endsWith("-costume", ignoreCase = true) }) return false
 
         if (form.labels.any { it in SIGNIFICANT_LABELS }) return true
+        if (hasSignificantAspect(form.aspects.toSet())) return true
 
         // A form with no distinguishing aspect can't meaningfully differ from
         // the species' own look (same "empty aspects = same as base" convention
@@ -641,7 +663,9 @@ object EvolutionDataLoader {
         return typeDiffers || statsDiffer || abilitiesDiffer
     }
 
-    private fun buildFormEntryKey(baseName: String, form: com.cobblemon.mod.common.pokemon.FormData, species: com.cobblemon.mod.common.pokemon.Species): String {
+    // Not private: DiagnosticService.showRawForms uses the real key so its
+    // "surfaced"/"in speciesInfo" checks match production exactly.
+    fun buildFormEntryKey(baseName: String, form: com.cobblemon.mod.common.pokemon.FormData, species: com.cobblemon.mod.common.pokemon.Species): String {
         // Regional forms reuse SpeciesNameNormalizer's pattern for dedup with spawn data (O3)
         val regionalLabel = form.labels.firstOrNull { it in REGIONAL_LABEL_TO_SUFFIX }
         if (regionalLabel != null) {

--- a/common/src/main/kotlin/com/cobbledex/EvolutionInfo.kt
+++ b/common/src/main/kotlin/com/cobbledex/EvolutionInfo.kt
@@ -313,6 +313,14 @@ data class EvolutionRequirement(
                 val status = cleanValue(data["status"])?.let { titleCase(it) }
                 status ?: tr("cobbledex-rei-emi-jei.evo.status_condition")
             }
+            // Synthetic requirement for fusion-mod results (see
+            // DerivedDataBuilder.rebuild) - these have no real Cobblemon
+            // Evolution data at all, only pokedex flavor text naming the
+            // other species involved.
+            "fusion_with" -> {
+                val partner = cleanValue(data["partner"]) ?: "?"
+                tr("cobbledex-rei-emi-jei.evo.fusion_with", partner)
+            }
             else -> {
                 val fallback = titleCase(variant)
                 if (fallback.length > 40 || fallback.contains("@") || (fallback.contains(".") && fallback.length > 30))

--- a/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
+++ b/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
@@ -782,13 +782,23 @@ object JarDataCache {
         // literal aspect string instead of extracting "overgrown" produced
         // a target key that matched no real form, silently falling back to
         // the base (non-Overgrown) Boldore.
+        //
+        // A boolean SPECIES FEATURE can also be toggled this way -
+        // "flaaffy rlm=true" (confirmed via Cobblemon RLM's Mareep->Flaaffy
+        // evolution, whose species_additions declares "features": ["rlm"])
+        // sets the boolean feature "rlm" to true, which itself contributes
+        // an aspect of the same name ("rlm") - unlike "aspect=X" the aspect
+        // name here IS the key, not the value, so this needs its own case.
         val resultParts = resultStr.split(" ").filter { it.isNotBlank() }
         val toSpecies = resultParts.first().lowercase()
         val toAspects = resultParts.drop(1).mapNotNull { token ->
             val lower = token.lowercase()
             when {
                 lower.startsWith("aspect=") -> lower.removePrefix("aspect=").ifBlank { null }
-                "=" in lower -> null // other properties (level=, gender=, shiny=, etc.) aren't aspects
+                "=" in lower -> {
+                    val (key, value) = lower.split("=", limit = 2)
+                    if (value == "true") key.ifBlank { null } else null
+                }
                 else -> lower
             }
         }.toSet()

--- a/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
+++ b/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
@@ -502,6 +502,14 @@ object JarDataCache {
         var baseEvoCount = 0
         var formEvoCount = 0
 
+        // "species/*.json" files declare a species outright via a "name" field.
+        // "species_additions/*.json" files patch an *existing* species (added by
+        // another mod/base game) and identify their target via a "target" field
+        // instead (e.g. "cobblemon:eevee") - no "name" field at all. Addon packs
+        // like Extra Eeveelutions/Kazeran Eeveelutions add their evolution
+        // branches this way, so both folders must be scanned or those branches
+        // are silently invisible even though the base species' own evolutions
+        // (from "species/") parse fine.
         for (root in modRoots) {
             try {
                 val dataDir = root.resolve("data")
@@ -509,91 +517,97 @@ object JarDataCache {
 
                 Files.list(dataDir).use { namespaces ->
                     namespaces.filter { Files.isDirectory(it) }.forEach { namespace ->
-                        val speciesDir = namespace.resolve("species")
-                        if (!Files.exists(speciesDir) || !Files.isDirectory(speciesDir)) return@forEach
+                        for ((folderName, isAddition) in listOf("species" to false, "species_additions" to true)) {
+                            val speciesDir = namespace.resolve(folderName)
+                            if (!Files.exists(speciesDir) || !Files.isDirectory(speciesDir)) continue
 
-                        Files.walk(speciesDir, 10).use { files ->
-                            files.filter { it.toString().endsWith(".json") && Files.isRegularFile(it) }.forEach { file ->
-                                try {
-                                    val obj = InputStreamReader(Files.newInputStream(file), Charsets.UTF_8).use { reader ->
-                                        JsonParser.parseReader(reader).asJsonObject
-                                    }
-
-                                    val name = obj.optString("name")?.lowercase() ?: return@forEach
-                                    fileCount++
-
-                                    // Parse moves
-                                    val movesArray = obj.optArray("moves")
-                                    if (movesArray != null) {
-                                        val levelUp = mutableMapOf<Int, MutableList<String>>()
-                                        val egg = mutableListOf<String>()
-                                        val tutor = mutableListOf<String>()
-                                        val tm = mutableListOf<String>()
-                                        for (elem in movesArray) {
-                                            try {
-                                                val str = elem.asString
-                                                val colonIdx = str.indexOf(':')
-                                                if (colonIdx < 1) continue
-                                                val prefix = str.substring(0, colonIdx)
-                                                val moveName = str.substring(colonIdx + 1)
-                                                when (prefix) {
-                                                    "egg" -> egg.add(moveName)
-                                                    "tm" -> tm.add(moveName)
-                                                    "tutor" -> tutor.add(moveName)
-                                                    else -> prefix.toIntOrNull()?.let { level ->
-                                                        levelUp.getOrPut(level) { mutableListOf() }.add(moveName)
-                                                    }
-                                                }
-                                            } catch (_: Exception) {}
+                            Files.walk(speciesDir, 10).use { files ->
+                                files.filter { it.toString().endsWith(".json") && Files.isRegularFile(it) }.forEach { file ->
+                                    try {
+                                        val obj = InputStreamReader(Files.newInputStream(file), Charsets.UTF_8).use { reader ->
+                                            JsonParser.parseReader(reader).asJsonObject
                                         }
-                                        if (levelUp.isNotEmpty() || egg.isNotEmpty() || tutor.isNotEmpty() || tm.isNotEmpty()) {
-                                            movesResult[name] = JarMoveData(levelUp, egg, tutor, tm)
-                                        }
-                                    }
 
-                                    // Base evolutions
-                                    val evolutions = obj.optArray("evolutions")
-                                    if (evolutions != null) {
-                                        for (evoElem in evolutions) {
-                                            try {
-                                                val info = parseEvolutionFromJson(name, null, evoElem.asJsonObject)
-                                                if (info != null) {
-                                                    result.getOrPut(name) { mutableListOf() }.add(info)
-                                                    baseEvoCount++
-                                                }
-                                            } catch (_: Exception) {}
-                                        }
-                                    }
+                                        val name = if (isAddition) {
+                                            obj.optString("target")?.substringAfter(':')?.lowercase()
+                                        } else {
+                                            obj.optString("name")?.lowercase()
+                                        } ?: return@forEach
+                                        fileCount++
 
-                                    // Form evolutions
-                                    val forms = obj.optArray("forms")
-                                    if (forms != null) {
-                                        for (formElem in forms) {
-                                            try {
-                                                val form = formElem.asJsonObject
-                                                val formEvos = form.optArray("evolutions") ?: continue
-                                                if (formEvos.isEmpty) continue
-
-                                                val aspects = form.optStringArray("aspects").toSet()
-                                                val formKey = if (aspects.isEmpty()) name
-                                                    else "$name ${aspects.sorted().joinToString(" ")}"
-
-                                                for (evoElem in formEvos) {
-                                                    try {
-                                                        val info = parseEvolutionFromJson(name, aspects, evoElem.asJsonObject)
-                                                        if (info != null) {
-                                                            result.getOrPut(formKey) { mutableListOf() }.add(info)
-                                                            if (formKey != name) {
-                                                                result.getOrPut(name) { mutableListOf() }.add(info)
-                                                            }
-                                                            formEvoCount++
+                                        // Parse moves
+                                        val movesArray = obj.optArray("moves")
+                                        if (movesArray != null) {
+                                            val levelUp = mutableMapOf<Int, MutableList<String>>()
+                                            val egg = mutableListOf<String>()
+                                            val tutor = mutableListOf<String>()
+                                            val tm = mutableListOf<String>()
+                                            for (elem in movesArray) {
+                                                try {
+                                                    val str = elem.asString
+                                                    val colonIdx = str.indexOf(':')
+                                                    if (colonIdx < 1) continue
+                                                    val prefix = str.substring(0, colonIdx)
+                                                    val moveName = str.substring(colonIdx + 1)
+                                                    when (prefix) {
+                                                        "egg" -> egg.add(moveName)
+                                                        "tm" -> tm.add(moveName)
+                                                        "tutor" -> tutor.add(moveName)
+                                                        else -> prefix.toIntOrNull()?.let { level ->
+                                                            levelUp.getOrPut(level) { mutableListOf() }.add(moveName)
                                                         }
-                                                    } catch (_: Exception) {}
-                                                }
-                                            } catch (_: Exception) {}
+                                                    }
+                                                } catch (_: Exception) {}
+                                            }
+                                            if (levelUp.isNotEmpty() || egg.isNotEmpty() || tutor.isNotEmpty() || tm.isNotEmpty()) {
+                                                movesResult[name] = JarMoveData(levelUp, egg, tutor, tm)
+                                            }
                                         }
-                                    }
-                                } catch (_: Exception) { failCount++ }
+
+                                        // Base evolutions
+                                        val evolutions = obj.optArray("evolutions")
+                                        if (evolutions != null) {
+                                            for (evoElem in evolutions) {
+                                                try {
+                                                    val info = parseEvolutionFromJson(name, null, evoElem.asJsonObject)
+                                                    if (info != null) {
+                                                        result.getOrPut(name) { mutableListOf() }.add(info)
+                                                        baseEvoCount++
+                                                    }
+                                                } catch (_: Exception) {}
+                                            }
+                                        }
+
+                                        // Form evolutions
+                                        val forms = obj.optArray("forms")
+                                        if (forms != null) {
+                                            for (formElem in forms) {
+                                                try {
+                                                    val form = formElem.asJsonObject
+                                                    val formEvos = form.optArray("evolutions") ?: continue
+                                                    if (formEvos.isEmpty) continue
+
+                                                    val aspects = form.optStringArray("aspects").toSet()
+                                                    val formKey = if (aspects.isEmpty()) name
+                                                        else "$name ${aspects.sorted().joinToString(" ")}"
+
+                                                    for (evoElem in formEvos) {
+                                                        try {
+                                                            val info = parseEvolutionFromJson(name, aspects, evoElem.asJsonObject)
+                                                            if (info != null) {
+                                                                result.getOrPut(formKey) { mutableListOf() }.add(info)
+                                                                if (formKey != name) {
+                                                                    result.getOrPut(name) { mutableListOf() }.add(info)
+                                                                }
+                                                                formEvoCount++
+                                                            }
+                                                        } catch (_: Exception) {}
+                                                    }
+                                                } catch (_: Exception) {}
+                                            }
+                                        }
+                                    } catch (_: Exception) { failCount++ }
+                                }
                             }
                         }
                     }

--- a/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
+++ b/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
@@ -499,14 +499,18 @@ object JarDataCache {
 
     // ==================== Evolution Parsing ====================
 
-    private fun parseEvolutionsAndMovesFromJars(modRoots: List<Path>): Triple<Map<String, List<EvolutionInfo>>, Map<String, JarMoveData>, Map<String, JarMoveData>> {
-        val result = mutableMapOf<String, MutableList<EvolutionInfo>>()
-        val movesResult = mutableMapOf<String, JarMoveData>()
-        val formMovesResult = mutableMapOf<String, JarMoveData>()
+    private class EvoMoveParseCounters {
         var fileCount = 0
         var failCount = 0
         var baseEvoCount = 0
         var formEvoCount = 0
+    }
+
+    private fun parseEvolutionsAndMovesFromJars(modRoots: List<Path>): Triple<Map<String, List<EvolutionInfo>>, Map<String, JarMoveData>, Map<String, JarMoveData>> {
+        val result = mutableMapOf<String, MutableList<EvolutionInfo>>()
+        val movesResult = mutableMapOf<String, JarMoveData>()
+        val formMovesResult = mutableMapOf<String, JarMoveData>()
+        val counters = EvoMoveParseCounters()
 
         // "species/*.json" files declare a species outright via a "name" field.
         // "species_additions/*.json" files patch an *existing* species (added by
@@ -518,104 +522,170 @@ object JarDataCache {
         // (from "species/") parse fine.
         for (root in modRoots) {
             try {
-                val dataDir = root.resolve("data")
-                if (!Files.exists(dataDir) || !Files.isDirectory(dataDir)) continue
-
-                Files.list(dataDir).use { namespaces ->
-                    namespaces.filter { Files.isDirectory(it) }.forEach { namespace ->
-                        for ((folderName, isAddition) in listOf("species" to false, "species_additions" to true)) {
-                            val speciesDir = namespace.resolve(folderName)
-                            if (!Files.exists(speciesDir) || !Files.isDirectory(speciesDir)) continue
-
-                            Files.walk(speciesDir, 10).use { files ->
-                                files.filter { it.toString().endsWith(".json") && Files.isRegularFile(it) }.forEach { file ->
-                                    try {
-                                        val obj = InputStreamReader(Files.newInputStream(file), Charsets.UTF_8).use { reader ->
-                                            JsonParser.parseReader(reader).asJsonObject
-                                        }
-
-                                        val name = if (isAddition) {
-                                            obj.optString("target")?.substringAfter(':')?.lowercase()
-                                        } else {
-                                            obj.optString("name")?.lowercase()
-                                        } ?: return@forEach
-                                        fileCount++
-
-                                        // Parse moves
-                                        val movesArray = obj.optArray("moves")
-                                        if (movesArray != null) {
-                                            parseMovesArray(movesArray)?.let { movesResult[name] = it }
-                                        }
-
-                                        // Base evolutions
-                                        val evolutions = obj.optArray("evolutions")
-                                        if (evolutions != null) {
-                                            for (evoElem in evolutions) {
-                                                try {
-                                                    val info = parseEvolutionFromJson(name, null, evoElem.asJsonObject)
-                                                    if (info != null) {
-                                                        result.getOrPut(name) { mutableListOf() }.add(info)
-                                                        baseEvoCount++
-                                                    }
-                                                } catch (_: Exception) {}
-                                            }
-                                        }
-
-                                        // Form evolutions + moves. Cobblemon's own client-side
-                                        // FormData only reliably syncs a species_additions form's
-                                        // LEVEL-UP moves - egg/tutor/tm entries nested inside
-                                        // "forms[].moves" routinely come back empty at runtime
-                                        // (confirmed via /cobbledex evo: Laser's Fakemon Pack's
-                                        // Fomantis Lunar form defines 102 moves in its JSON, but
-                                        // Cobblemon's runtime form.moves only exposed the 13
-                                        // level-up ones, losing all 59 TM/20 tutor/10 egg moves).
-                                        // Parsed here from the raw JSON as a fallback source,
-                                        // keyed identically to the runtime form key so
-                                        // enrichWithJarMoves can fill the gap per-form instead of
-                                        // only for the bare base species.
-                                        val forms = obj.optArray("forms")
-                                        if (forms != null) {
-                                            for (formElem in forms) {
-                                                try {
-                                                    val form = formElem.asJsonObject
-                                                    val aspects = form.optStringArray("aspects").toSet()
-                                                    val formKey = if (aspects.isEmpty()) name
-                                                        else buildJsonFormEntryKey(name, form)
-
-                                                    val formMovesArray = form.optArray("moves")
-                                                    if (formMovesArray != null) {
-                                                        parseMovesArray(formMovesArray)?.let { formMovesResult[formKey] = it }
-                                                    }
-
-                                                    val formEvos = form.optArray("evolutions")
-                                                    if (formEvos != null && !formEvos.isEmpty) {
-                                                        for (evoElem in formEvos) {
-                                                            try {
-                                                                val info = parseEvolutionFromJson(name, aspects, evoElem.asJsonObject)
-                                                                if (info != null) {
-                                                                    result.getOrPut(formKey) { mutableListOf() }.add(info)
-                                                                    if (formKey != name) {
-                                                                        result.getOrPut(name) { mutableListOf() }.add(info)
-                                                                    }
-                                                                    formEvoCount++
-                                                                }
-                                                            } catch (_: Exception) {}
-                                                        }
-                                                    }
-                                                } catch (_: Exception) {}
-                                            }
-                                        }
-                                    } catch (_: Exception) { failCount++ }
-                                }
-                            }
-                        }
-                    }
-                }
+                scanLooseSpeciesDataDir(root.resolve("data"), result, movesResult, formMovesResult, counters)
             } catch (_: Exception) {}
         }
 
-        DebugLog.info("JarDataCache: parsed $baseEvoCount base + $formEvoCount form evolutions from $fileCount species files ($failCount failed)")
+        // modRoots only enumerates Fabric-registered mod jars - content
+        // shipped as a loose/zipped datapack or resourcepack (e.g. Fanmade
+        // Form Funfair ships as a resourcepack zip, relying on the
+        // ResourcePackOverrides mod to also apply its data/ folder as real
+        // game data) never showed up here at all, even on setups where
+        // Cobblemon's own runtime *did* load that content correctly - so
+        // this raw-JSON fallback had nothing to merge in for it (confirmed
+        // via /cobbledex evo: Fanmade Form Funfair's Roggenrola/Boldore
+        // "Overgrown" species_additions files were invisible to JarDataCache
+        // entirely, not just misparsed).
+        try {
+            val gameDir = com.cobbledex.platform.PlatformHelper.getGameDir()
+            // Global datapacks (via the Globalpacks mod) apply unconditionally,
+            // but resourcepacks are opt-in per options.txt's "resourcePacks"
+            // list - the folder itself commonly holds disabled packs too (this
+            // modpack keeps several "DO NOT ENABLE, credits only" packs sitting
+            // right next to active ones, with hundreds of their own species
+            // files). Scanning those unconditionally would silently blend in
+            // evolution/move data for content the player never actually
+            // enabled, so resourcepacks are filtered to the enabled set;
+            // datapacks are not.
+            val enabledResourcePackFiles = readEnabledResourcePackFileNames(gameDir)
+            for (folderName in listOf("datapacks", "resourcepacks")) {
+                val dir = gameDir.resolve(folderName)
+                if (!Files.exists(dir) || !Files.isDirectory(dir)) continue
+                val isResourcePacks = folderName == "resourcepacks"
+
+                Files.list(dir).use { entries ->
+                    entries.filter { Files.isDirectory(it) }
+                        .filter { !isResourcePacks || it.fileName.toString() in enabledResourcePackFiles }
+                        .forEach { pack ->
+                            scanLooseSpeciesDataDir(pack.resolve("data"), result, movesResult, formMovesResult, counters)
+                        }
+                }
+
+                val zipFilter: (Path) -> Boolean = { path ->
+                    !isResourcePacks || path.fileName.toString() in enabledResourcePackFiles
+                }
+                for ((subFolder, isAddition) in listOf("species" to false, "species_additions" to true)) {
+                    scanZipDatapacks(dir, subFolder, zipFilter) { _, _, json ->
+                        processSpeciesJsonObject(json, isAddition, result, movesResult, formMovesResult, counters)
+                    }
+                }
+            }
+        } catch (_: Exception) {}
+
+        DebugLog.info("JarDataCache: parsed ${counters.baseEvoCount} base + ${counters.formEvoCount} form evolutions from ${counters.fileCount} species files (${counters.failCount} failed)")
         return Triple(result, movesResult, formMovesResult)
+    }
+
+    private fun scanLooseSpeciesDataDir(
+        dataDir: Path,
+        result: MutableMap<String, MutableList<EvolutionInfo>>,
+        movesResult: MutableMap<String, JarMoveData>,
+        formMovesResult: MutableMap<String, JarMoveData>,
+        counters: EvoMoveParseCounters,
+    ) {
+        if (!Files.exists(dataDir) || !Files.isDirectory(dataDir)) return
+
+        Files.list(dataDir).use { namespaces ->
+            namespaces.filter { Files.isDirectory(it) }.forEach { namespace ->
+                for ((folderName, isAddition) in listOf("species" to false, "species_additions" to true)) {
+                    val speciesDir = namespace.resolve(folderName)
+                    if (!Files.exists(speciesDir) || !Files.isDirectory(speciesDir)) continue
+
+                    Files.walk(speciesDir, 10).use { files ->
+                        files.filter { it.toString().endsWith(".json") && Files.isRegularFile(it) }.forEach { file ->
+                            try {
+                                val obj = InputStreamReader(Files.newInputStream(file), Charsets.UTF_8).use { reader ->
+                                    JsonParser.parseReader(reader).asJsonObject
+                                }
+                                processSpeciesJsonObject(obj, isAddition, result, movesResult, formMovesResult, counters)
+                            } catch (_: Exception) { counters.failCount++ }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun processSpeciesJsonObject(
+        obj: JsonObject,
+        isAddition: Boolean,
+        result: MutableMap<String, MutableList<EvolutionInfo>>,
+        movesResult: MutableMap<String, JarMoveData>,
+        formMovesResult: MutableMap<String, JarMoveData>,
+        counters: EvoMoveParseCounters,
+    ) {
+        try {
+            val name = if (isAddition) {
+                obj.optString("target")?.substringAfter(':')?.lowercase()
+            } else {
+                obj.optString("name")?.lowercase()
+            } ?: return
+            counters.fileCount++
+
+            // Parse moves
+            val movesArray = obj.optArray("moves")
+            if (movesArray != null) {
+                parseMovesArray(movesArray)?.let { movesResult[name] = it }
+            }
+
+            // Base evolutions
+            val evolutions = obj.optArray("evolutions")
+            if (evolutions != null) {
+                for (evoElem in evolutions) {
+                    try {
+                        val info = parseEvolutionFromJson(name, null, evoElem.asJsonObject)
+                        if (info != null) {
+                            result.getOrPut(name) { mutableListOf() }.add(info)
+                            counters.baseEvoCount++
+                        }
+                    } catch (_: Exception) {}
+                }
+            }
+
+            // Form evolutions + moves. Cobblemon's own client-side FormData
+            // only reliably syncs a species_additions form's LEVEL-UP moves -
+            // egg/tutor/tm entries nested inside "forms[].moves" routinely
+            // come back empty at runtime (confirmed via /cobbledex evo:
+            // Laser's Fakemon Pack's Fomantis Lunar form defines 102 moves in
+            // its JSON, but Cobblemon's runtime form.moves only exposed the
+            // 13 level-up ones, losing all 59 TM/20 tutor/10 egg moves).
+            // Parsed here from the raw JSON as a fallback source, keyed
+            // identically to the runtime form key so enrichWithJarMoves can
+            // fill the gap per-form instead of only for the bare base
+            // species.
+            val forms = obj.optArray("forms")
+            if (forms != null) {
+                for (formElem in forms) {
+                    try {
+                        val form = formElem.asJsonObject
+                        val aspects = form.optStringArray("aspects").toSet()
+                        val formKey = if (aspects.isEmpty()) name
+                            else buildJsonFormEntryKey(name, form)
+
+                        val formMovesArray = form.optArray("moves")
+                        if (formMovesArray != null) {
+                            parseMovesArray(formMovesArray)?.let { formMovesResult[formKey] = it }
+                        }
+
+                        val formEvos = form.optArray("evolutions")
+                        if (formEvos != null && !formEvos.isEmpty) {
+                            for (evoElem in formEvos) {
+                                try {
+                                    val info = parseEvolutionFromJson(name, aspects, evoElem.asJsonObject)
+                                    if (info != null) {
+                                        result.getOrPut(formKey) { mutableListOf() }.add(info)
+                                        if (formKey != name) {
+                                            result.getOrPut(name) { mutableListOf() }.add(info)
+                                        }
+                                        counters.formEvoCount++
+                                    }
+                                } catch (_: Exception) {}
+                            }
+                        }
+                    } catch (_: Exception) {}
+                }
+            }
+        } catch (_: Exception) { counters.failCount++ }
     }
 
     private fun parseMovesArray(movesArray: JsonArray): JarMoveData? {
@@ -676,10 +746,24 @@ object JarDataCache {
         val id = evo.optString("id") ?: return null
         val resultStr = evo.optString("result") ?: return null
 
-        // Result can be "species" or "species aspect1 aspect2"
-        val resultParts = resultStr.split(" ")
+        // Result can be "species", "species aspect1 aspect2", or use
+        // Cobblemon's PokemonProperties key=value syntax for the aspect,
+        // e.g. "boldore aspect=overgrown" (confirmed via /cobbledex evo:
+        // Fanmade Form Funfair's Roggenrola->Boldore Overgrown evolution
+        // uses this form) - naively treating "aspect=overgrown" as the
+        // literal aspect string instead of extracting "overgrown" produced
+        // a target key that matched no real form, silently falling back to
+        // the base (non-Overgrown) Boldore.
+        val resultParts = resultStr.split(" ").filter { it.isNotBlank() }
         val toSpecies = resultParts.first().lowercase()
-        val toAspects = if (resultParts.size > 1) resultParts.drop(1).map { it.lowercase() }.toSet() else emptySet()
+        val toAspects = resultParts.drop(1).mapNotNull { token ->
+            val lower = token.lowercase()
+            when {
+                lower.startsWith("aspect=") -> lower.removePrefix("aspect=").ifBlank { null }
+                "=" in lower -> null // other properties (level=, gender=, shiny=, etc.) aren't aspects
+                else -> lower
+            }
+        }.toSet()
 
         val variant = evo.optString("variant") ?: "level_up"
         val consumeHeldItem = evo.optBool("consumeHeldItem") ?: false
@@ -883,14 +967,36 @@ object JarDataCache {
 
     // ==================== ZIP Datapack Scanning ====================
 
+    // options.txt's "resourcePacks" line is a JSON array where each active
+    // resourcepack file is listed as "file/<name>.zip" (built-in packs like
+    // "vanilla" or namespaced ones like "cobblemon:uniqueshinyforms" aren't
+    // files on disk, so they're irrelevant here). Returns just the bare
+    // filenames, matching Path.fileName.toString() for the resourcepacks/
+    // folder.
+    private fun readEnabledResourcePackFileNames(gameDir: Path): Set<String> {
+        return try {
+            val optionsFile = gameDir.resolve("options.txt")
+            if (!Files.exists(optionsFile)) return emptySet()
+            val line = Files.readAllLines(optionsFile, Charsets.UTF_8)
+                .firstOrNull { it.startsWith("resourcePacks:") } ?: return emptySet()
+            val arrayJson = line.substringAfter("resourcePacks:")
+            val array = JsonParser.parseString(arrayJson).asJsonArray
+            array.mapNotNull { it.asString.takeIf { s -> s.startsWith("file/") }?.removePrefix("file/") }.toSet()
+        } catch (e: Exception) {
+            DebugLog.once("resourcepack-enabled-list") { "Failed to read enabled resourcepacks from options.txt: ${e.message}" }
+            emptySet()
+        }
+    }
+
     private fun scanZipDatapacks(
         datapacksDir: Path,
         subDir: String,
+        packFilter: (Path) -> Boolean = { true },
         handler: (namespace: String, entryName: String, json: JsonObject) -> Unit
     ) {
         try {
             Files.list(datapacksDir).use { packs ->
-                packs.filter { it.toString().endsWith(".zip") && Files.isRegularFile(it) }.forEach { zipPath ->
+                packs.filter { it.toString().endsWith(".zip") && Files.isRegularFile(it) && packFilter(it) }.forEach { zipPath ->
                     try {
                         ZipFile(zipPath.toFile()).use { zip ->
                             val pattern = Regex("^data/([^/]+)/${subDir}/.+\\.json\$")

--- a/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
+++ b/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
@@ -28,6 +28,8 @@ object JarDataCache {
     @Volatile
     private var cachedMoves: Map<String, JarMoveData> = emptyMap()
     @Volatile
+    private var cachedFormMoves: Map<String, JarMoveData> = emptyMap()
+    @Volatile
     private var cachedFossils: Map<String, List<FossilCombo>> = emptyMap()
 
     /** Raw move data parsed from species JSON in mod JARs. */
@@ -51,6 +53,8 @@ object JarDataCache {
     fun hasCachedSpawns(): Boolean = cachedSpawns.isNotEmpty()
     fun hasCachedMoves(): Boolean = cachedMoves.isNotEmpty()
     fun getCachedMoves(): Map<String, JarMoveData> = cachedMoves
+    fun hasCachedFormMoves(): Boolean = cachedFormMoves.isNotEmpty()
+    fun getCachedFormMoves(): Map<String, JarMoveData> = cachedFormMoves
     fun hasCachedFossils(): Boolean = cachedFossils.isNotEmpty()
     fun getCachedFossils(): Map<String, List<FossilCombo>> = cachedFossils
 
@@ -82,6 +86,7 @@ object JarDataCache {
             val evoAndMoves = parseEvolutionsAndMovesFromJars(modRoots)
             cachedEvolutions = evoAndMoves.first
             cachedMoves = evoAndMoves.second
+            cachedFormMoves = evoAndMoves.third
             cachedFossils = parseFossilsFromJars(modRoots)
 
             val elapsed = System.currentTimeMillis() - startTime
@@ -494,9 +499,10 @@ object JarDataCache {
 
     // ==================== Evolution Parsing ====================
 
-    private fun parseEvolutionsAndMovesFromJars(modRoots: List<Path>): Pair<Map<String, List<EvolutionInfo>>, Map<String, JarMoveData>> {
+    private fun parseEvolutionsAndMovesFromJars(modRoots: List<Path>): Triple<Map<String, List<EvolutionInfo>>, Map<String, JarMoveData>, Map<String, JarMoveData>> {
         val result = mutableMapOf<String, MutableList<EvolutionInfo>>()
         val movesResult = mutableMapOf<String, JarMoveData>()
+        val formMovesResult = mutableMapOf<String, JarMoveData>()
         var fileCount = 0
         var failCount = 0
         var baseEvoCount = 0
@@ -538,30 +544,7 @@ object JarDataCache {
                                         // Parse moves
                                         val movesArray = obj.optArray("moves")
                                         if (movesArray != null) {
-                                            val levelUp = mutableMapOf<Int, MutableList<String>>()
-                                            val egg = mutableListOf<String>()
-                                            val tutor = mutableListOf<String>()
-                                            val tm = mutableListOf<String>()
-                                            for (elem in movesArray) {
-                                                try {
-                                                    val str = elem.asString
-                                                    val colonIdx = str.indexOf(':')
-                                                    if (colonIdx < 1) continue
-                                                    val prefix = str.substring(0, colonIdx)
-                                                    val moveName = str.substring(colonIdx + 1)
-                                                    when (prefix) {
-                                                        "egg" -> egg.add(moveName)
-                                                        "tm" -> tm.add(moveName)
-                                                        "tutor" -> tutor.add(moveName)
-                                                        else -> prefix.toIntOrNull()?.let { level ->
-                                                            levelUp.getOrPut(level) { mutableListOf() }.add(moveName)
-                                                        }
-                                                    }
-                                                } catch (_: Exception) {}
-                                            }
-                                            if (levelUp.isNotEmpty() || egg.isNotEmpty() || tutor.isNotEmpty() || tm.isNotEmpty()) {
-                                                movesResult[name] = JarMoveData(levelUp, egg, tutor, tm)
-                                            }
+                                            parseMovesArray(movesArray)?.let { movesResult[name] = it }
                                         }
 
                                         // Base evolutions
@@ -578,30 +561,46 @@ object JarDataCache {
                                             }
                                         }
 
-                                        // Form evolutions
+                                        // Form evolutions + moves. Cobblemon's own client-side
+                                        // FormData only reliably syncs a species_additions form's
+                                        // LEVEL-UP moves - egg/tutor/tm entries nested inside
+                                        // "forms[].moves" routinely come back empty at runtime
+                                        // (confirmed via /cobbledex evo: Laser's Fakemon Pack's
+                                        // Fomantis Lunar form defines 102 moves in its JSON, but
+                                        // Cobblemon's runtime form.moves only exposed the 13
+                                        // level-up ones, losing all 59 TM/20 tutor/10 egg moves).
+                                        // Parsed here from the raw JSON as a fallback source,
+                                        // keyed identically to the runtime form key so
+                                        // enrichWithJarMoves can fill the gap per-form instead of
+                                        // only for the bare base species.
                                         val forms = obj.optArray("forms")
                                         if (forms != null) {
                                             for (formElem in forms) {
                                                 try {
                                                     val form = formElem.asJsonObject
-                                                    val formEvos = form.optArray("evolutions") ?: continue
-                                                    if (formEvos.isEmpty) continue
-
                                                     val aspects = form.optStringArray("aspects").toSet()
                                                     val formKey = if (aspects.isEmpty()) name
-                                                        else "$name ${aspects.sorted().joinToString(" ")}"
+                                                        else buildJsonFormEntryKey(name, form)
 
-                                                    for (evoElem in formEvos) {
-                                                        try {
-                                                            val info = parseEvolutionFromJson(name, aspects, evoElem.asJsonObject)
-                                                            if (info != null) {
-                                                                result.getOrPut(formKey) { mutableListOf() }.add(info)
-                                                                if (formKey != name) {
-                                                                    result.getOrPut(name) { mutableListOf() }.add(info)
+                                                    val formMovesArray = form.optArray("moves")
+                                                    if (formMovesArray != null) {
+                                                        parseMovesArray(formMovesArray)?.let { formMovesResult[formKey] = it }
+                                                    }
+
+                                                    val formEvos = form.optArray("evolutions")
+                                                    if (formEvos != null && !formEvos.isEmpty) {
+                                                        for (evoElem in formEvos) {
+                                                            try {
+                                                                val info = parseEvolutionFromJson(name, aspects, evoElem.asJsonObject)
+                                                                if (info != null) {
+                                                                    result.getOrPut(formKey) { mutableListOf() }.add(info)
+                                                                    if (formKey != name) {
+                                                                        result.getOrPut(name) { mutableListOf() }.add(info)
+                                                                    }
+                                                                    formEvoCount++
                                                                 }
-                                                                formEvoCount++
-                                                            }
-                                                        } catch (_: Exception) {}
+                                                            } catch (_: Exception) {}
+                                                        }
                                                     }
                                                 } catch (_: Exception) {}
                                             }
@@ -616,7 +615,61 @@ object JarDataCache {
         }
 
         DebugLog.info("JarDataCache: parsed $baseEvoCount base + $formEvoCount form evolutions from $fileCount species files ($failCount failed)")
-        return Pair(result, movesResult)
+        return Triple(result, movesResult, formMovesResult)
+    }
+
+    private fun parseMovesArray(movesArray: JsonArray): JarMoveData? {
+        val levelUp = mutableMapOf<Int, MutableList<String>>()
+        val egg = mutableListOf<String>()
+        val tutor = mutableListOf<String>()
+        val tm = mutableListOf<String>()
+        for (elem in movesArray) {
+            try {
+                val str = elem.asString
+                val colonIdx = str.indexOf(':')
+                if (colonIdx < 1) continue
+                val prefix = str.substring(0, colonIdx)
+                val moveName = str.substring(colonIdx + 1)
+                when (prefix) {
+                    "egg" -> egg.add(moveName)
+                    "tm" -> tm.add(moveName)
+                    "tutor" -> tutor.add(moveName)
+                    else -> prefix.toIntOrNull()?.let { level ->
+                        levelUp.getOrPut(level) { mutableListOf() }.add(moveName)
+                    }
+                }
+            } catch (_: Exception) {}
+        }
+        if (levelUp.isEmpty() && egg.isEmpty() && tutor.isEmpty() && tm.isEmpty()) return null
+        return JarMoveData(levelUp, egg, tutor, tm)
+    }
+
+    // Mirrors EvolutionDataLoader.buildFormEntryKey's scheme exactly (underscore-
+    // joined, regional forms suffixed with no separator) so a form's evolution
+    // ends up keyed identically whether it was read from Cobblemon's live API
+    // or from this raw-JSON fallback. The two used to diverge - this path
+    // joined "$name ${aspects...}" with a SPACE, which normalizeMapKeys' key
+    // normalizer (SpeciesNameNormalizer.normalize) then stripped entirely
+    // (space isn't a permitted character) instead of turning into a separator,
+    // collapsing e.g. "fomantis lunar" into "fomantislunar" - a key that
+    // matched nothing else in the pipeline, silently breaking that form's own
+    // evolution lookup and leaving a phantom, data-less duplicate species key.
+    private val REGIONAL_LABEL_TO_SUFFIX = mapOf(
+        "alolan_form" to "alolan",
+        "galarian_form" to "galarian",
+        "hisuian_form" to "hisuian",
+        "paldean_form" to "paldean"
+    )
+
+    private fun buildJsonFormEntryKey(name: String, form: JsonObject): String {
+        val labels = form.optStringArray("labels")
+        val regionalLabel = labels.firstOrNull { it in REGIONAL_LABEL_TO_SUFFIX }
+        if (regionalLabel != null) {
+            return "${SpeciesNameNormalizer.normalize(name)}${REGIONAL_LABEL_TO_SUFFIX[regionalLabel]}"
+        }
+        val formName = form.optString("name")?.lowercase()?.replace(Regex("[^a-z0-9]"), "")
+        if (formName.isNullOrBlank()) return name
+        return "${SpeciesNameNormalizer.normalize(name)}_$formName"
     }
 
     private fun parseEvolutionFromJson(fromSpecies: String, fromAspects: Set<String>?, evo: JsonObject): EvolutionInfo? {

--- a/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
+++ b/common/src/main/kotlin/com/cobbledex/JarDataCache.kt
@@ -615,11 +615,22 @@ object JarDataCache {
         counters: EvoMoveParseCounters,
     ) {
         try {
-            val name = if (isAddition) {
+            val rawName = if (isAddition) {
                 obj.optString("target")?.substringAfter(':')?.lowercase()
             } else {
                 obj.optString("name")?.lowercase()
             } ?: return
+            // Species' own "name" field is a display name and can contain
+            // spaces/punctuation (e.g. "Great Tusk", "Iron Treads", "Ting-Lu",
+            // "Mime Jr.") - every other map in the pipeline is keyed by
+            // SpeciesNameNormalizer.normalize()'d ids, so leaving this one
+            // unnormalized meant movesResult["great tusk"] (with a space)
+            // never matched enrichWithJarMoves's lookup by the real
+            // normalized key "greattusk", silently losing that species' TM/
+            // tutor/egg move fallback entirely (confirmed via the exported
+            // CobbleDex spreadsheet: Great Tusk showed only its 17 level-up
+            // moves, none of its 53 TM + 25 tutor moves).
+            val name = SpeciesNameNormalizer.normalize(rawName)
             counters.fileCount++
 
             // Parse moves
@@ -731,11 +742,28 @@ object JarDataCache {
         "paldean_form" to "paldean"
     )
 
+    // Mirrors EvolutionDataLoader.REGIONAL_ASPECT_TO_SUFFIX - falls back to
+    // the form's aspect when its labels don't carry a recognized regional
+    // marker, in case a mod's own JSON omits/misdeclares "labels" the way
+    // Cobblemon's runtime FormData was found to for Farfetch'd Galar
+    // (aspect stayed correct even when the runtime label didn't).
+    private val REGIONAL_ASPECT_TO_SUFFIX = mapOf(
+        "alolan" to "alolan",
+        "galarian" to "galarian",
+        "hisuian" to "hisuian",
+        "paldean" to "paldean"
+    )
+
     private fun buildJsonFormEntryKey(name: String, form: JsonObject): String {
         val labels = form.optStringArray("labels")
         val regionalLabel = labels.firstOrNull { it in REGIONAL_LABEL_TO_SUFFIX }
-        if (regionalLabel != null) {
-            return "${SpeciesNameNormalizer.normalize(name)}${REGIONAL_LABEL_TO_SUFFIX[regionalLabel]}"
+        val regionalSuffix = if (regionalLabel != null) {
+            REGIONAL_LABEL_TO_SUFFIX[regionalLabel]
+        } else {
+            form.optStringArray("aspects").map { it.lowercase() }.firstNotNullOfOrNull { REGIONAL_ASPECT_TO_SUFFIX[it] }
+        }
+        if (regionalSuffix != null) {
+            return "${SpeciesNameNormalizer.normalize(name)}$regionalSuffix"
         }
         val formName = form.optString("name")?.lowercase()?.replace(Regex("[^a-z0-9]"), "")
         if (formName.isNullOrBlank()) return name

--- a/common/src/main/kotlin/com/cobbledex/PageFamilyBuilders.kt
+++ b/common/src/main/kotlin/com/cobbledex/PageFamilyBuilders.kt
@@ -278,13 +278,6 @@ object PokemonInfoPageBuilder {
             height += SpawnDisplayHelper.wrapText(font, bstText, valueWidth).size.coerceAtLeast(1) * PanelLayout.LINE_HEIGHT
         }
 
-        if (data.differenceReasons.isNotEmpty()) {
-            height += 3 + PanelLayout.LINE_HEIGHT
-            height += data.differenceReasons.sumOf { reason ->
-                SpawnDisplayHelper.wrapText(font, "• $reason", width - (padding + 6)).size.coerceAtLeast(1) * PanelLayout.LINE_HEIGHT
-            }
-        }
-
         height += 1 + 4 + font.lineHeight + padding
         return height
     }

--- a/common/src/main/kotlin/com/cobbledex/PageFamilyBuilders.kt
+++ b/common/src/main/kotlin/com/cobbledex/PageFamilyBuilders.kt
@@ -308,15 +308,28 @@ object PokemonInfoPageBuilder {
         layout.fill(padding, 36, right, 37, 0x50FFFFFF)
         layout.skipTo(43)
 
-        info?.description?.takeIf { it.isNotBlank() }?.let { description ->
-            val lines = SpawnDisplayHelper.wrapText(font, description, right - indentX).take(3)
-            lines.forEach { line ->
-                layout.clipped(indentX, line, right - indentX, 0xCCCCCC)
-                layout.line()
+        info?.description?.takeIf { it.isNotBlank() }?.let { descriptionKey ->
+            // info.description stores a translation KEY (e.g.
+            // "cobblemon.species.sableye_bloodmoon.desc1"), not resolved
+            // text - the separate "Pokemon Description" REI category
+            // correctly calls tr() on it (SpawnDisplayHelper.
+            // buildPokemonDescriptionLayout), but this inline overview
+            // snippet never did, so it rendered the raw key literally
+            // whenever a species reached this page before that other
+            // category (confirmed via Fai's Mythical Monstrosities' Sableye
+            // Bloodmoon, whose Overview page showed
+            // "cobblemon.species.sableye_bloodmoon.desc1" as-is).
+            val description = tr(descriptionKey)
+            if (description != descriptionKey && description.isNotBlank()) {
+                val lines = SpawnDisplayHelper.wrapText(font, description, right - indentX).take(3)
+                lines.forEach { line ->
+                    layout.clipped(indentX, line, right - indentX, 0xCCCCCC)
+                    layout.line()
+                }
+                layout.gap(3)
+                layout.separator(0x18FFFFFF)
+                layout.gap(4)
             }
-            layout.gap(3)
-            layout.separator(0x18FFFFFF)
-            layout.gap(4)
         }
 
         drawOverviewSection(layout, tr("cobbledex-rei-emi-jei.overview.profile"))

--- a/common/src/main/kotlin/com/cobbledex/PokemonSpriteAtlas.kt
+++ b/common/src/main/kotlin/com/cobbledex/PokemonSpriteAtlas.kt
@@ -219,6 +219,57 @@ object PokemonSpriteAtlas {
         return BuildResult(atlasPath, manifestPath, keys.size, images.size, failed)
     }
 
+    // For the companion Pokedex website: full-size individual PNGs (not the
+    // small REI atlas) named exactly by SpriteKey.id, so an external pipeline
+    // can match them against its own normalized species+aspects without any
+    // coupling to this mod's internal file layout.
+    fun exportWebsiteSprites(size: Int, sender: DiagnosticService.MessageSender): Int {
+        if (buildInProgress) {
+            sender.send("§eA CobbleDex sprite build/export is already running.")
+            return 0
+        }
+        if (!SpawnDataIndex.hasData()) {
+            sender.send(tr("cobbledex-rei-emi-jei.cmd.no_data_short"))
+            return 0
+        }
+
+        buildInProgress = true
+        sender.send("§7Exporting $size" + "x" + "$size Pokemon sprites for the website...")
+        Minecraft.getInstance().execute {
+            try {
+                val keys = collectSpriteKeys()
+                val outputDir = cacheDir().resolve("website-sprites")
+                Files.createDirectories(outputDir)
+                IconCapture.init()
+                var captured = 0
+                var failed = 0
+                keys.forEachIndexed { index, resolved ->
+                    val png = IconCapture.captureSpeciesToPng(resolved.renderSpecies, resolved.renderAspects, size)
+                    if (png != null) {
+                        Files.write(outputDir.resolve("${resolved.key.id}.png"), png)
+                        captured++
+                    } else {
+                        failed++
+                    }
+                    val completed = index + 1
+                    if (completed == keys.size || completed % 50 == 0) {
+                        sender.send("§7Exported: $completed/${keys.size}")
+                    }
+                }
+                sender.send("§aWebsite sprite export done: $captured/${keys.size} captured, $failed failed")
+                sender.send("§7${outputDir.toAbsolutePath()}")
+            } catch (t: Throwable) {
+                sender.send("§cWebsite sprite export failed: ${t.message ?: t.javaClass.simpleName}")
+                DebugLog.warn("Website sprite export failed: ${t.message}")
+                t.printStackTrace()
+            } finally {
+                buildInProgress = false
+                IconCapture.cleanup()
+            }
+        }
+        return 1
+    }
+
     private fun collectSpriteKeys(): List<ResolvedSpriteKey> {
         val queries = SpawnDataIndex.currentQueries()
         val names = SpawnDataIndex.allSpeciesNames.ifEmpty { SpawnDataIndex.speciesInfo.keys.sorted() }

--- a/common/src/main/kotlin/com/cobbledex/PokemonSpriteAtlas.kt
+++ b/common/src/main/kotlin/com/cobbledex/PokemonSpriteAtlas.kt
@@ -95,7 +95,29 @@ object PokemonSpriteAtlas {
             }
         )
 
-        return ResolvedSpriteKey(SpriteKey(renderSpecies, aspects), renderSpecies, aspects)
+        // Most species' bedrock resolvers have a model variation that matches
+        // with no gender aspect at all, so this normally doesn't matter - but
+        // some (e.g. Lively Mons' Fungalith) define ONLY "male"/"female"
+        // variations with no genderless fallback. Requesting a render with
+        // neither aspect then matches nothing, and Cobblemon silently falls
+        // back to the "Substitute" placeholder doll instead of the species'
+        // own model. Default to a gender aspect whenever the species isn't
+        // genderless (maleRatio == -1), same convention Cobblemon's own box/
+        // party UI uses when showing a species with no live Pokemon instance
+        // to pull an actual gender from. Kept OUT of the SpriteKey/id itself
+        // (only affects the actual render call) so the atlas/website
+        // filenames stay exactly as every other lookup already expects them -
+        // this is purely "which pose Cobblemon renders", not a new identity.
+        val renderAspects = if ("male" in aspects || "female" in aspects) {
+            aspects
+        } else {
+            val maleRatio = info?.maleRatio
+            if (maleRatio != null && maleRatio != -1f) {
+                aspects + if (maleRatio == 0f) "female" else "male"
+            } else aspects
+        }
+
+        return ResolvedSpriteKey(SpriteKey(renderSpecies, aspects), renderSpecies, renderAspects)
     }
 
     fun renderIfAvailable(

--- a/common/src/main/kotlin/com/cobbledex/PokemonSpriteAtlas.kt
+++ b/common/src/main/kotlin/com/cobbledex/PokemonSpriteAtlas.kt
@@ -13,7 +13,13 @@ import java.nio.file.Path
 import javax.imageio.ImageIO
 
 object PokemonSpriteAtlas {
-    private const val ATLAS_VERSION = 2
+    // Bump whenever a change would make an already-cached atlas render
+    // something wrong (not just add new content) - a mismatched version
+    // number is what makes ensureAtlas() below treat an existing player's
+    // on-disk cache as stale and silently rebuild it once, instead of them
+    // being stuck with an old incorrect render (e.g. Fungalith's Substitute-
+    // doll bug) until they think to run /cobbledex sprites build themselves.
+    private const val ATLAS_VERSION = 3
     private const val SPRITE_SIZE = 64
     private const val ATLAS_COLUMNS = 32
     private const val CACHE_DIR = "cobbledex-sprites"
@@ -79,6 +85,38 @@ object PokemonSpriteAtlas {
     @Volatile private var loadedAtlas: LoadedAtlas? = null
     @Volatile private var loadAttempted = false
     @Volatile private var buildInProgress = false
+    private val ensureAttempted = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    // Called once per session (see CobbleDexMod.tickReloadCheck) right after
+    // spawn/species data finishes loading, so players never have to know
+    // /cobbledex sprites build exists just to see correct icons/renders. If
+    // a cached atlas already exists and matches ATLAS_VERSION it's left
+    // alone (instant, no rebuild); otherwise a fresh one is built silently
+    // in the background - this is the only path that makes an ATLAS_VERSION
+    // bump (e.g. after a render-affecting fix) actually reach existing
+    // players instead of them staying stuck on their old cached PNG.
+    fun ensureAtlas() {
+        if (!ensureAttempted.compareAndSet(false, true)) return
+        // Checked directly against the cache (not getLoadedAtlas/tryLoadAtlas,
+        // which would silently accept the jar-bundled default atlas as "good
+        // enough") - the bundled atlas is a fixed snapshot baked at build
+        // time that can't reflect this modpack's own fakemons/fixes, so
+        // treating it as sufficient here would mean the auto-build never
+        // fires and players stay on a wrong/incomplete atlas forever.
+        val cached = tryLoadCacheAtlas()
+        if (cached != null) {
+            loadedAtlas = cached
+            loadAttempted = true
+            return
+        }
+        DebugLog.info("No up-to-date cached Pokemon sprite atlas found - building automatically in the background")
+        buildAtlas { msg -> DebugLog.info(msg) }
+    }
+
+    /** Allows ensureAtlas() to check again after reconnecting (e.g. to a different server/pack setup). */
+    fun resetEnsureAttempt() {
+        ensureAttempted.set(false)
+    }
 
     fun resolve(species: String, explicitAspects: Set<String> = emptySet()): ResolvedSpriteKey {
         val normalized = SpeciesNameNormalizer.normalize(species)

--- a/common/src/main/kotlin/com/cobbledex/RecipeBuilder.kt
+++ b/common/src/main/kotlin/com/cobbledex/RecipeBuilder.kt
@@ -121,12 +121,14 @@ object RecipeBuilder {
         val incomingSources = queries.getEvolutionsTo(normalized)
             .map { evolution -> resolveEvolutionSourceKey(evolution, queries) }
 
-        val formBaseSource = queries.getSpeciesInfo(normalized)
+        // The immediate parent for a mega/primal/gmax-style transform isn't
+        // always the base species - e.g. "Mega Midnight" transforms from
+        // "Midnight", not from base Lucario (see resolveTransformParent).
+        val transformParentSource = queries.getSpeciesInfo(normalized)
             ?.takeIf { info -> info.formAspects.isNotEmpty() }
-            ?.baseSpeciesName
-            ?.let(SpeciesNameNormalizer::normalize)
+            ?.let { info -> resolveTransformParent(normalized, info.formAspects, queries)?.first }
 
-        return (incomingSources + listOfNotNull(formBaseSource))
+        return (incomingSources + listOfNotNull(transformParentSource))
             .distinct()
             .flatMap { source -> buildEvolutionPagesFor(source, snapshot) }
             .filter { page -> SpeciesNameNormalizer.normalize(page.targetSpeciesName.orEmpty()) == normalized }
@@ -660,26 +662,25 @@ object RecipeBuilder {
                 )
             }
 
-        val transformTargets = if (sourceAspects.isEmpty()) {
-            queries.getFormsOf(sourceSpeciesName).mapNotNull { info ->
-                val label = info.labels.orEmpty().map(String::lowercase)
-                val methodText = when {
-                    "mega" in label -> tr("cobbledex-rei-emi-jei.evo.form_change.mega")
-                    "primal" in label -> tr("cobbledex-rei-emi-jei.evo.form_change.primal")
-                    "ultra_burst" in label -> tr("cobbledex-rei-emi-jei.evo.form_change.ultra_burst")
-                    "gmax" in label -> tr("cobbledex-rei-emi-jei.evo.form_change.gmax")
-                    else -> null
-                } ?: return@mapNotNull null
-
-                EvolutionTargetPage(
-                    targetSpeciesName = info.name,
-                    targetAspects = info.formAspects,
-                    methods = listOf(EvolutionMethodRecipeData(methodText)),
-                    priority = 1,
-                )
-            }
-        } else {
-            emptyList()
+        // Mega/Mega-Z/Gmax-style transforms have no real Cobblemon Evolution
+        // data behind them at all (confirmed via /cobbledex forms: Lucario's
+        // 23 forms and its species.evolutions/form.evolutions are all empty) -
+        // Cobblemon just registers them as forms with a distinguishing aspect.
+        // So the only way to find these is to compare aspect sets across the
+        // whole family (base + every sibling form) and infer parent/child
+        // transform edges from them - see resolveTransformParent's comment.
+        val sourceAspectsRaw = sourceAspects.map { it.lowercase() }.toSet()
+        val family = buildFamilyAspectMembers(sourceSpeciesName, queries)
+        val transformTargets = family.mapNotNull { (targetKey, targetAspects) ->
+            if (targetAspects == sourceAspectsRaw || !targetAspects.containsAll(sourceAspectsRaw)) return@mapNotNull null
+            val parent = findTransformParent(targetAspects, family) ?: return@mapNotNull null
+            if (parent.second != sourceAspectsRaw) return@mapNotNull null
+            EvolutionTargetPage(
+                targetSpeciesName = targetKey,
+                targetAspects = targetAspects,
+                methods = listOf(EvolutionMethodRecipeData(parent.third)),
+                priority = 1,
+            )
         }
 
         return (directTargets + transformTargets)
@@ -689,7 +690,10 @@ object RecipeBuilder {
             )
     }
 
-    private fun resolveEvolutionTargetKey(
+    // Not private: DerivedDataBuilder reuses this to index the "what evolves
+    // into X" reverse map by the exact aspect-qualified form (e.g.
+    // "lucario_midnight"), not just the bare species name - see its usage there.
+    fun resolveEvolutionTargetKey(
         targetSpeciesName: String,
         targetAspects: Set<String>,
         snapshot: CobbleDexDataSnapshot,
@@ -712,6 +716,79 @@ object RecipeBuilder {
         aspects.map { aspect ->
             aspect.lowercase().replace(Regex("[^a-z0-9]"), "")
         }.filter { it.isNotBlank() }.toSet()
+
+    // (speciesKey, raw lowercase aspects) for the base species plus every
+    // sibling form - used to infer mega/primal/gmax-style transform edges
+    // by comparing aspect sets directly, since Cobblemon doesn't back these
+    // with real Evolution data (see buildEvolutionTargets' comment). Aspects
+    // are kept raw/unstripped here (not run through normalizeAspects) so
+    // markers like "mega_z" or "chef-costume" stay recognizable by prefix/
+    // suffix in transformMethodTextFor and the costume filter upstream.
+    private fun buildFamilyAspectMembers(
+        speciesName: String,
+        queries: CobbleDexDataQueries,
+    ): List<Pair<String, Set<String>>> {
+        val realBaseName = queries.getSpeciesInfo(speciesName)?.baseSpeciesName
+            ?.let(SpeciesNameNormalizer::normalize)
+            ?: SpeciesNameNormalizer.normalize(speciesName)
+        val siblings = queries.getFormsOf(realBaseName).map { info ->
+            info.name to info.formAspects.map { it.lowercase() }.toSet()
+        }
+        return listOf(realBaseName to emptySet<String>()) + siblings
+    }
+
+    private val TRANSFORM_ASPECT_MARKERS = mapOf(
+        "cobbledex-rei-emi-jei.evo.form_change.mega" to setOf("mega"),
+        "cobbledex-rei-emi-jei.evo.form_change.primal" to setOf("primal"),
+        "cobbledex-rei-emi-jei.evo.form_change.ultra_burst" to setOf("ultra_burst"),
+        "cobbledex-rei-emi-jei.evo.form_change.gmax" to setOf("gmax", "gigantamax"),
+    )
+
+    // Recognizes not just an exact aspect match ("mega") but also namespaced
+    // variants a mod might register for custom mega-likes ("mega_z",
+    // "mega-y") so third-party additions still get labeled sensibly instead
+    // of being silently dropped from the evolution chain.
+    private fun transformMethodTextFor(addedAspects: Set<String>): String? {
+        for ((trKey, markers) in TRANSFORM_ASPECT_MARKERS) {
+            val matches = addedAspects.any { aspect ->
+                markers.any { marker -> aspect == marker || aspect.startsWith("${marker}_") || aspect.startsWith("${marker}-") }
+            }
+            if (matches) return tr(trKey)
+        }
+        return null
+    }
+
+    // Finds the closest family member whose aspect set is a proper subset of
+    // targetAspects and whose "new" aspects (relative to that member) read as
+    // a mega/primal/gmax-style transform. "Closest" = the candidate with the
+    // largest aspect set, so e.g. a "Mega Midnight" form (aspects=[mega_y,y])
+    // resolves to "Midnight" (aspects=[y]) as its parent rather than jumping
+    // all the way back to the base species - both are technically subsets,
+    // but Midnight is the direct one.
+    private fun findTransformParent(
+        targetAspects: Set<String>,
+        familyMembers: List<Pair<String, Set<String>>>,
+    ): Triple<String, Set<String>, String>? {
+        var best: Triple<String, Set<String>, String>? = null
+        for ((key, aspects) in familyMembers) {
+            if (aspects == targetAspects || !targetAspects.containsAll(aspects)) continue
+            val methodText = transformMethodTextFor(targetAspects - aspects) ?: continue
+            if (best == null || aspects.size > best.second.size) {
+                best = Triple(key, aspects, methodText)
+            }
+        }
+        return best
+    }
+
+    private fun resolveTransformParent(
+        speciesName: String,
+        speciesAspects: Set<String>,
+        queries: CobbleDexDataQueries,
+    ): Triple<String, Set<String>, String>? {
+        val family = buildFamilyAspectMembers(speciesName, queries)
+        val targetAspects = speciesAspects.map { it.lowercase() }.toSet()
+        return findTransformParent(targetAspects, family)
+    }
 
     private fun resolveEvolutionSourceKey(
         evolution: EvolutionInfo,

--- a/common/src/main/kotlin/com/cobbledex/SpawnDataIndex.kt
+++ b/common/src/main/kotlin/com/cobbledex/SpawnDataIndex.kt
@@ -272,11 +272,44 @@ object SpawnDataIndex {
                 evolutionSourceTier = DataSourceTier.UNKNOWN
             }
 
-            // Fall back to JarDataCache evolutions if runtime is empty
-            if (evolutionsBySpecies.isEmpty() && JarDataCache.hasCachedEvolutions()) {
-                DebugLog.info("Using JarDataCache evolutions (${JarDataCache.getCachedEvolutions().size} species)")
-                evolutionsBySpecies = normalizeMapKeys(JarDataCache.getCachedEvolutions())
-                evolutionSourceTier = DataSourceTier.JAR_OR_DATAPACK
+            // Fall back to JarDataCache evolutions wholesale if runtime is
+            // completely empty (e.g. evolution access itself failed), then
+            // merge in any form-specific edges the runtime API is missing
+            // even when it did return data overall - Cobblemon's client-side
+            // FormData for a species_additions-nested form's own "evolutions"
+            // routinely comes back empty at runtime even though the mod's
+            // JSON defines a real one (confirmed via /cobbledex evo: Fanmade
+            // Form Funfair's Roggenrola/Boldore "Overgrown" forms both define
+            // a real level_up/trade evolution in their species_additions
+            // file, but Cobblemon's runtime form.evolutions exposed none of
+            // it, so only the aspectless base Roggenrola->Boldore edge ever
+            // reached RecipeBuilder).
+            if (JarDataCache.hasCachedEvolutions()) {
+                if (evolutionsBySpecies.isEmpty()) {
+                    DebugLog.info("Using JarDataCache evolutions (${JarDataCache.getCachedEvolutions().size} species)")
+                    evolutionsBySpecies = normalizeMapKeys(JarDataCache.getCachedEvolutions())
+                    evolutionSourceTier = DataSourceTier.JAR_OR_DATAPACK
+                } else {
+                    val merged = evolutionsBySpecies.mapValues { it.value.toMutableList() }.toMutableMap()
+                    var addedCount = 0
+                    for ((key, jarEvos) in normalizeMapKeys(JarDataCache.getCachedEvolutions())) {
+                        val existing = merged[key].orEmpty()
+                        for (evo in jarEvos) {
+                            val alreadyPresent = existing.any {
+                                it.fromAspects == evo.fromAspects &&
+                                    SpeciesNameNormalizer.normalize(it.toSpecies) == SpeciesNameNormalizer.normalize(evo.toSpecies)
+                            }
+                            if (!alreadyPresent) {
+                                merged.getOrPut(key) { mutableListOf() }.add(evo)
+                                addedCount++
+                            }
+                        }
+                    }
+                    if (addedCount > 0) {
+                        evolutionsBySpecies = merged
+                        DebugLog.info("Merged $addedCount form-specific evolution edges from JarDataCache (runtime API didn't provide them)")
+                    }
+                }
             }
 
             try {

--- a/common/src/main/kotlin/com/cobbledex/SpawnDataIndex.kt
+++ b/common/src/main/kotlin/com/cobbledex/SpawnDataIndex.kt
@@ -459,17 +459,30 @@ object SpawnDataIndex {
     /**
      * Fill in missing move data from JarDataCache when the runtime API
      * didn't provide egg/tutor/tm/level-up moves (common on dedicated-server clients).
+     *
+     * A form's own move data is checked first (formJarMoves, keyed by the same
+     * form key as speciesInfo) before falling back to the base species' moves
+     * (jarMoves, bare-name keyed) - Cobblemon's client-side FormData for a
+     * species_additions-nested form routinely only syncs its LEVEL-UP moves,
+     * silently dropping any egg/tutor/tm moves the form defines on its own
+     * (confirmed via /cobbledex evo: Laser's Fakemon Pack's Fomantis Lunar
+     * form defines 102 moves of its own, but Cobblemon's runtime form.moves
+     * only exposed the 13 level-up ones). Falling back straight to the base
+     * species' moves in that case would silently substitute the wrong
+     * Pokemon's moveset instead of the form's own (missing) one.
      */
     private fun enrichWithJarMoves() {
-        if (!JarDataCache.hasCachedMoves()) return
+        if (!JarDataCache.hasCachedMoves() && !JarDataCache.hasCachedFormMoves()) return
         if (speciesInfo.isEmpty()) return
         val jarMoves = JarDataCache.getCachedMoves()
+        val formJarMoves = JarDataCache.getCachedFormMoves()
 
         val enriched = speciesInfo.toMutableMap()
         var enrichCount = 0
 
         for ((species, info) in enriched) {
-            val jarData = jarMoves[species] ?: continue
+            val baseKey = info.baseSpeciesName ?: species
+            val jarData = formJarMoves[species] ?: jarMoves[baseKey] ?: continue
             val needsEnrichment = info.levelUpMoves == null || info.eggMoves == null ||
                 info.tutorMoves == null || info.tmMoves == null
             if (!needsEnrichment) continue

--- a/common/src/main/kotlin/com/cobbledex/SpawnDisplayHelper.kt
+++ b/common/src/main/kotlin/com/cobbledex/SpawnDisplayHelper.kt
@@ -1936,15 +1936,6 @@ object SpawnDisplayHelper {
             drawDetailRow("BST", tr("cobbledex-rei-emi-jei.stats.bst", bst) + delta, bstColor)
         }
 
-        if (data.differenceReasons.isNotEmpty()) {
-            layout.gap(3)
-            layout.text(padding, "Notable differences", 0xEEEEEE)
-            layout.line()
-            data.differenceReasons.forEach { reason ->
-                layout.wrapped(padding + 6, "• $reason", right - (padding + 6), 0xBBBBBB)
-            }
-        }
-
         layout.gap(1)
         layout.separator(0x20FFFFFF)
         layout.gap(4)

--- a/common/src/main/resources/assets/cobbledex-rei-emi-jei/lang/en_us.json
+++ b/common/src/main/resources/assets/cobbledex-rei-emi-jei/lang/en_us.json
@@ -174,6 +174,7 @@
   "cobbledex-rei-emi-jei.evo.friendship": "Friendship %d+",
   "cobbledex-rei-emi-jei.evo.trade": "Trade",
   "cobbledex-rei-emi-jei.evo.trade_with": "Trade with %s",
+  "cobbledex-rei-emi-jei.evo.fusion_with": "Fuse with %s",
   "cobbledex-rei-emi-jei.evo.use_item": "Use item",
   "cobbledex-rei-emi-jei.evo.use_item_named": "Use %s",
   "cobbledex-rei-emi-jei.evo.click_block": "Click %s block",

--- a/common/src/main/resources/assets/cobbledex-rei-emi-jei/lang/es_es.json
+++ b/common/src/main/resources/assets/cobbledex-rei-emi-jei/lang/es_es.json
@@ -27,6 +27,7 @@
   "cobbledex-rei-emi-jei.evo.friendship": "Amistad %d+",
   "cobbledex-rei-emi-jei.evo.trade": "Intercambio",
   "cobbledex-rei-emi-jei.evo.trade_with": "Intercambio con %s",
+  "cobbledex-rei-emi-jei.evo.fusion_with": "Fusión con %s",
   "cobbledex-rei-emi-jei.evo.use_item": "Usar objeto",
   "cobbledex-rei-emi-jei.evo.use_item_named": "Usar %s",
   "cobbledex-rei-emi-jei.evo.click_block": "Clic en bloque %s",

--- a/common/src/main/resources/assets/cobbledex-rei-emi-jei/lang/es_mx.json
+++ b/common/src/main/resources/assets/cobbledex-rei-emi-jei/lang/es_mx.json
@@ -27,6 +27,7 @@
   "cobbledex-rei-emi-jei.evo.friendship": "Amistad %d+",
   "cobbledex-rei-emi-jei.evo.trade": "Intercambio",
   "cobbledex-rei-emi-jei.evo.trade_with": "Intercambio con %s",
+  "cobbledex-rei-emi-jei.evo.fusion_with": "Fusión con %s",
   "cobbledex-rei-emi-jei.evo.use_item": "Usar objeto",
   "cobbledex-rei-emi-jei.evo.use_item_named": "Usar %s",
   "cobbledex-rei-emi-jei.evo.click_block": "Clic en bloque %s",

--- a/fabric/src/main/kotlin/com/cobbledex/fabric/CobbleDexFabricClient.kt
+++ b/fabric/src/main/kotlin/com/cobbledex/fabric/CobbleDexFabricClient.kt
@@ -106,6 +106,16 @@ class CobbleDexFabricClient : ClientModInitializer {
                             }
                         }
                     )
+                    .then(ClientCommandManager.literal("forms")
+                        .then(ClientCommandManager.argument("species", com.mojang.brigadier.arguments.StringArgumentType.word())
+                            .executes { ctx ->
+                                val species = com.mojang.brigadier.arguments.StringArgumentType.getString(ctx, "species")
+                                DiagnosticService.showRawForms(species) { msg ->
+                                    ctx.source.sendFeedback(Component.literal(msg))
+                                }
+                            }
+                        )
+                    )
                     .then(ClientCommandManager.literal("reload")
                         .executes { ctx ->
                             DiagnosticService.reloadData { msg ->

--- a/fabric/src/main/kotlin/com/cobbledex/fabric/CobbleDexFabricClient.kt
+++ b/fabric/src/main/kotlin/com/cobbledex/fabric/CobbleDexFabricClient.kt
@@ -116,6 +116,16 @@ class CobbleDexFabricClient : ClientModInitializer {
                             }
                         )
                     )
+                    .then(ClientCommandManager.literal("evo")
+                        .then(ClientCommandManager.argument("formKey", com.mojang.brigadier.arguments.StringArgumentType.word())
+                            .executes { ctx ->
+                                val formKey = com.mojang.brigadier.arguments.StringArgumentType.getString(ctx, "formKey")
+                                DiagnosticService.showEvoPages(formKey) { msg ->
+                                    ctx.source.sendFeedback(Component.literal(msg))
+                                }
+                            }
+                        )
+                    )
                     .then(ClientCommandManager.literal("reload")
                         .executes { ctx ->
                             DiagnosticService.reloadData { msg ->

--- a/fabric/src/main/kotlin/com/cobbledex/fabric/CobbleDexFabricClient.kt
+++ b/fabric/src/main/kotlin/com/cobbledex/fabric/CobbleDexFabricClient.kt
@@ -145,6 +145,21 @@ class CobbleDexFabricClient : ClientModInitializer {
                                 1
                             }
                         )
+                        .then(ClientCommandManager.literal("export")
+                            .executes { ctx ->
+                                PokemonSpriteAtlas.exportWebsiteSprites(512) { msg ->
+                                    ctx.source.sendFeedback(Component.literal(msg))
+                                }
+                            }
+                            .then(ClientCommandManager.argument("size", com.mojang.brigadier.arguments.IntegerArgumentType.integer(32, 1024))
+                                .executes { ctx ->
+                                    val size = com.mojang.brigadier.arguments.IntegerArgumentType.getInteger(ctx, "size")
+                                    PokemonSpriteAtlas.exportWebsiteSprites(size) { msg ->
+                                        ctx.source.sendFeedback(Component.literal(msg))
+                                    }
+                                }
+                            )
+                        )
                     )
             )
         }


### PR DESCRIPTION
## Summary

While setting up a companion Pokedex website for a modpack (~15 Pokemon/fakemon mod jars + ~50 datapacks), I ran into several issues with the Evolution Chain tab and tracked them down to a handful of root causes in the data-loading and inference logic. All fixes were validated in-game against a live modpack server.

- **Base-of-family species showed no outgoing evolution branches.** The Pokemon Overview navigator only ever calls `buildRecipesFor()` (incoming direction) per category, so e.g. Eevee showed nothing even though it has plenty of outgoing branches. `EvolutionDex.buildRecipesFor` now combines both directions.
- **`species_additions` evolution data was never scanned by the jar fallback parser** - only the `species/` folder was, so compat/addon mods that only patch via `species_additions` had their evolution branches silently dropped when runtime data wasn't yet available.
- **Cobblemon's own internal "Normal" form was being treated as a real alternate form**, producing a bogus `<species>_normal` duplicate for most of the dex and double-counting evolutions (once from the base species, once from the "Normal" form).
- **The reverse "evolves from" lookup ignored aspect qualifiers**, so any evolution whose target was a specific aspect-qualified form (not the bare species) never showed up as that form's incoming evolution.
- **Cosmetic wardrobe items (`data/cobblemon/cosmetic_items`) are genuinely registered as their own `FormData` entries by Cobblemon**, and were surfacing as bogus duplicate alternate forms / evolution outcomes (e.g. "Mega Chef Costume" showing up instead of plain "Mega"). Confirmed via a debug dump of raw `species.forms` - these are reliably identifiable by an aspect ending in `-costume`.
- **Mega/Mega-Z/Gmax-style transform evolutions have no real `Evolution` data behind them at all** in Cobblemon (confirmed empty `species.evolutions`/`form.evolutions` via the same dump). They were previously inferred only against the base species using an exact label match (`"mega" in label`), which missed custom mega variants (e.g. `"mega_z"`) and mis-attributed multi-step transforms (e.g. a "Mega Midnight" form) to the base species instead of the correct intermediate form ("Midnight"). Now inferred generically by comparing aspect sets across the whole family of sibling forms, matching any `mega*`/`primal`/`gmax` aspect pattern rather than a hardcoded label string.
- **`CategorySizer`'s early-exit panel-size sampling** under-measured bounds for outlier content, causing text overflow in the Evolution/Alternate Forms panels.

Also added a `/cobbledex forms <species>` debug command that dumps Cobblemon's raw `species.forms` / `species.evolutions` / per-form `evolutions` for one species - this is what let me confirm the last two root causes empirically instead of guessing, and should make similar data-source issues easier to diagnose in the future.

## Test plan

- [x] Verified in-game against a live Cobbleverse modpack server (15+ Pokemon/fakemon mods, ~50 datapacks)
- [x] Eevee now shows its full outgoing evolution family in the Evolution tab
- [x] Lucario (Midnight) correctly shows its incoming evolution from Riolu
- [x] Cosmetic costume packs (tested with a wardrobe-item resourcepack) no longer produce duplicate "Mega X Costume" alternate forms/evolution outcomes
- [x] Lucario base to Mega / Mega-Z shown as direct transforms; Lucario (Midnight) to Mega Midnight shown as its own transform; Lucario (Mega-Z)'s own page shows it evolving from base Lucario
- [x] No new compile warnings beyond pre-existing ones